### PR TITLE
[feat] Add sim2sim module

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,30 @@ Additional evaluation options include `--save_trajectories` to save trajectory d
 </details>
 
 <details>
+<summary> Sim to MuJoCo </summary>
+
+### Sim to MuJoCo
+
+We provide a **generic Sim2MuJoCo framework** that enables seamless policy transfer from Isaac Lab to MuJoCo simulation. The framework is task-agnostic and automatically handles observation/action mapping by parsing the exported I/O descriptor YAML file—no code changes needed for different tasks.
+
+**Quick Start:**
+
+1. Export policy and I/O descriptor from your trained checkpoint
+2. Get robot MJCF from [Unitree's official repository](https://github.com/unitreerobotics/unitree_mujoco) or bring your own
+3. Run evaluation in MuJoCo
+
+```bash
+python scripts/sim2mujoco_eval.py \
+  --checkpoint path/to/policy.pt \
+  --config path/to/config.yaml \
+  --mjcf unitree_mujoco/unitree_robots/g1/scene_29dof.xml
+```
+
+For detailed instructions on exporting policies and I/O descriptors, see [scripts/README.md](scripts/README.md#sim2mujoco_evalpy).
+
+</details>
+
+<details>
 <summary> Testing </summary>
 
 ### Testing
@@ -404,7 +428,7 @@ Note: The `third_party` directory is excluded from all pre-commit hooks to prese
 </details>
 
 ## Deployment
-Policy deployment for both sim-to-sim and sim-to-real transfer currently utilizes NVIDIA's internal deployment framework, which is planned for public release in the near future.
+Policy deployment for sim-to-real transfer currently utilizes NVIDIA's internal deployment framework, which is planned for public release in the near future.
 
 **Pre-trained Policies:** We include several verified pre-trained checkpoints in the repository for evaluation and deployment. See [`agile/data/policy/README.md`](agile/data/policy/README.md) for available policies and usage instructions.
 

--- a/agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_teacher.yaml
+++ b/agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_teacher.yaml
@@ -1,0 +1,603 @@
+observations:
+  policy:
+    - name: generated_commands
+      overloads:
+        clip: null
+        scale: null
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        description: The generated command from command term in the command manager with the given name.
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.generated_commands
+      shape:
+        - 4
+      dtype: torch.float32
+      observation_type: Command
+    - name: base_lin_vel
+      overloads:
+        clip: null
+        scale: null
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        units: m/s
+        axes:
+          - X
+          - Y
+          - Z
+        description: Root linear velocity in the asset's root frame.
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.base_lin_vel
+      shape:
+        - 3
+      dtype: torch.float32
+      observation_type: RootState
+    - name: base_ang_vel
+      overloads:
+        clip: null
+        scale: null
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        units: rad/s
+        axes:
+          - X
+          - Y
+          - Z
+        description: Root angular velocity in the asset's root frame.
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.base_ang_vel
+      shape:
+        - 3
+      dtype: torch.float32
+      observation_type: RootState
+    - name: projected_gravity
+      overloads:
+        clip: null
+        scale: null
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        units: m/s^2
+        axes:
+          - X
+          - Y
+          - Z
+        description: Gravity projection on the asset's root frame.
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.projected_gravity
+      shape:
+        - 3
+      dtype: torch.float32
+      observation_type: RootState
+    - name: joint_pos_rel
+      overloads:
+        clip: null
+        scale: null
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        units: rad
+        description: 'The joint positions of the asset w.r.t. the default joint positions. Note: Only the joints configured in :attr:`asset_cfg.joint_ids` will have their positions returned.'
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.joint_pos_rel
+      shape:
+        - 29
+      dtype: torch.float32
+      observation_type: JointState
+      joint_names:
+        - left_hip_pitch_joint
+        - right_hip_pitch_joint
+        - waist_yaw_joint
+        - left_hip_roll_joint
+        - right_hip_roll_joint
+        - waist_roll_joint
+        - left_hip_yaw_joint
+        - right_hip_yaw_joint
+        - waist_pitch_joint
+        - left_knee_joint
+        - right_knee_joint
+        - left_shoulder_pitch_joint
+        - right_shoulder_pitch_joint
+        - left_ankle_pitch_joint
+        - right_ankle_pitch_joint
+        - left_shoulder_roll_joint
+        - right_shoulder_roll_joint
+        - left_ankle_roll_joint
+        - right_ankle_roll_joint
+        - left_shoulder_yaw_joint
+        - right_shoulder_yaw_joint
+        - left_elbow_joint
+        - right_elbow_joint
+        - left_wrist_roll_joint
+        - right_wrist_roll_joint
+        - left_wrist_pitch_joint
+        - right_wrist_pitch_joint
+        - left_wrist_yaw_joint
+        - right_wrist_yaw_joint
+      joint_pos_offsets:
+        - -0.10000000149011612
+        - -0.10000000149011612
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.30000001192092896
+        - 0.30000001192092896
+        - 0.0
+        - 0.0
+        - -0.20000000298023224
+        - -0.20000000298023224
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+    - name: joint_vel_rel
+      overloads:
+        clip: null
+        scale: 0.10000000149011612
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        units: rad/s
+        description: 'The joint velocities of the asset w.r.t. the default joint velocities. Note: Only the joints configured in :attr:`asset_cfg.joint_ids` will have their velocities returned.'
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.joint_vel_rel
+      shape:
+        - 29
+      dtype: torch.float32
+      observation_type: JointState
+      joint_names:
+        - left_hip_pitch_joint
+        - right_hip_pitch_joint
+        - waist_yaw_joint
+        - left_hip_roll_joint
+        - right_hip_roll_joint
+        - waist_roll_joint
+        - left_hip_yaw_joint
+        - right_hip_yaw_joint
+        - waist_pitch_joint
+        - left_knee_joint
+        - right_knee_joint
+        - left_shoulder_pitch_joint
+        - right_shoulder_pitch_joint
+        - left_ankle_pitch_joint
+        - right_ankle_pitch_joint
+        - left_shoulder_roll_joint
+        - right_shoulder_roll_joint
+        - left_ankle_roll_joint
+        - right_ankle_roll_joint
+        - left_shoulder_yaw_joint
+        - right_shoulder_yaw_joint
+        - left_elbow_joint
+        - right_elbow_joint
+        - left_wrist_roll_joint
+        - right_wrist_roll_joint
+        - left_wrist_pitch_joint
+        - right_wrist_pitch_joint
+        - left_wrist_yaw_joint
+        - right_wrist_yaw_joint
+      joint_vel_offsets:
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+    - name: last_action
+      overloads:
+        clip:
+          - -10.0
+          - 10.0
+        scale: null
+        history_length: 0
+        flatten_history_dim: true
+      extras:
+        description: The last input action to the environment. The name of the action term for which the action is required. If None, the entire action tensor is returned.
+        modifiers: null
+      mdp_type: Observation
+      full_path: isaaclab.envs.mdp.observations.last_action
+      shape:
+        - 12
+      dtype: torch.float32
+      observation_type: Action
+actions:
+  - name: joint_position_action
+    extras:
+      description: Joint action term that applies the processed actions to the articulation's joints as position commands.
+    mdp_type: Action
+    full_path: isaaclab.envs.mdp.actions.joint_actions.JointPositionAction
+    shape:
+      - 12
+    dtype: torch.float32
+    action_type: JointAction
+    joint_names:
+      - left_hip_pitch_joint
+      - right_hip_pitch_joint
+      - left_hip_roll_joint
+      - right_hip_roll_joint
+      - left_hip_yaw_joint
+      - right_hip_yaw_joint
+      - left_knee_joint
+      - right_knee_joint
+      - left_ankle_pitch_joint
+      - right_ankle_pitch_joint
+      - left_ankle_roll_joint
+      - right_ankle_roll_joint
+    scale:
+      - - 0.5475464463233948
+        - 0.5475464463233948
+        - 0.3506614565849304
+        - 0.3506614565849304
+        - 0.5475464463233948
+        - 0.5475464463233948
+        - 0.3506614565849304
+        - 0.3506614565849304
+        - 0.4385773241519928
+        - 0.4385773241519928
+        - 0.4385773241519928
+        - 0.4385773241519928
+    offset:
+      - -0.10000000149011612
+      - -0.10000000149011612
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.30000001192092896
+      - 0.30000001192092896
+      - -0.20000000298023224
+      - -0.20000000298023224
+      - 0.0
+      - 0.0
+    clip:
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+      - - -6.0
+        - 6.0
+  - name: harness_action
+    extras:
+      description: Harness action to help a bipedal robot walk. We are using the sensor base class but this is not a sensor per seay. We measure from the height sensor the height and Orientatation from the articaulation root. We apply corrictive force torque to the root of the robot to keep the robot upright and at the desired height. We then use a curiculum to reduce the forces applied to the robot. This way we teach the robot to stand up and walk without falling over.
+    mdp_type: Action
+    full_path: agile.rl_env.mdp.actions.harness_action.HarnessAction
+    shape: null
+    dtype: null
+    action_type: null
+articulations:
+  robot:
+    joint_names:
+      - left_hip_pitch_joint
+      - right_hip_pitch_joint
+      - waist_yaw_joint
+      - left_hip_roll_joint
+      - right_hip_roll_joint
+      - waist_roll_joint
+      - left_hip_yaw_joint
+      - right_hip_yaw_joint
+      - waist_pitch_joint
+      - left_knee_joint
+      - right_knee_joint
+      - left_shoulder_pitch_joint
+      - right_shoulder_pitch_joint
+      - left_ankle_pitch_joint
+      - right_ankle_pitch_joint
+      - left_shoulder_roll_joint
+      - right_shoulder_roll_joint
+      - left_ankle_roll_joint
+      - right_ankle_roll_joint
+      - left_shoulder_yaw_joint
+      - right_shoulder_yaw_joint
+      - left_elbow_joint
+      - right_elbow_joint
+      - left_wrist_roll_joint
+      - right_wrist_roll_joint
+      - left_wrist_pitch_joint
+      - right_wrist_pitch_joint
+      - left_wrist_yaw_joint
+      - right_wrist_yaw_joint
+    default_joint_pos:
+      - -0.10000000149011612
+      - -0.10000000149011612
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.30000001192092896
+      - 0.30000001192092896
+      - 0.0
+      - 0.0
+      - -0.20000000298023224
+      - -0.20000000298023224
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+    default_joint_vel:
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+    default_joint_pos_limits:
+      - - -2.5306997299194336
+        - 2.8797998428344727
+      - - -2.5306997299194336
+        - 2.8797998428344727
+      - - -2.618000030517578
+        - 2.618000030517578
+      - - -0.5235999226570129
+        - 2.967099666595459
+      - - -2.967099666595459
+        - 0.5235999226570129
+      - - -0.5199999213218689
+        - 0.5199999213218689
+      - - -2.7576000690460205
+        - 2.7576000690460205
+      - - -2.7576000690460205
+        - 2.7576000690460205
+      - - -0.5199999213218689
+        - 0.5199999213218689
+      - - -0.08726699650287628
+        - 2.8797998428344727
+      - - -0.08726699650287628
+        - 2.8797998428344727
+      - - -3.0891997814178467
+        - 2.6703999042510986
+      - - -3.0891997814178467
+        - 2.6703999042510986
+      - - -0.8726699352264404
+        - 0.5235999226570129
+      - - -0.8726699352264404
+        - 0.5235999226570129
+      - - -1.5881999731063843
+        - 2.251499652862549
+      - - -2.251499652862549
+        - 1.5881999731063843
+      - - -0.26179996132850647
+        - 0.26179996132850647
+      - - -0.26179996132850647
+        - 0.26179996132850647
+      - - -2.618000030517578
+        - 2.618000030517578
+      - - -2.618000030517578
+        - 2.618000030517578
+      - - -1.0471998453140259
+        - 2.0943996906280518
+      - - -1.0471998453140259
+        - 2.0943996906280518
+      - - -1.972221851348877
+        - 1.972221851348877
+      - - -1.972221851348877
+        - 1.972221851348877
+      - - -1.6144295930862427
+        - 1.6144295930862427
+      - - -1.6144295930862427
+        - 1.6144295930862427
+      - - -1.6144295930862427
+        - 1.6144295930862427
+      - - -1.6144295930862427
+        - 1.6144295930862427
+    default_joint_damping:
+      - 2.557889699935913
+      - 2.557889699935913
+      - 5.0
+      - 6.308801651000977
+      - 6.308801651000977
+      - 5.0
+      - 2.557889699935913
+      - 2.557889699935913
+      - 5.0
+      - 6.308801651000977
+      - 6.308801651000977
+      - 2.0
+      - 2.0
+      - 1.8144457340240479
+      - 1.8144457340240479
+      - 1.0
+      - 1.0
+      - 1.8144457340240479
+      - 1.8144457340240479
+      - 0.4000000059604645
+      - 0.4000000059604645
+      - 1.0
+      - 1.0
+      - 0.20000000298023224
+      - 0.20000000298023224
+      - 0.20000000298023224
+      - 0.20000000298023224
+      - 0.20000000298023224
+      - 0.20000000298023224
+    default_joint_stiffness:
+      - 40.179237365722656
+      - 40.179237365722656
+      - 300.0
+      - 99.09842681884766
+      - 99.09842681884766
+      - 300.0
+      - 40.179237365722656
+      - 40.179237365722656
+      - 300.0
+      - 99.09842681884766
+      - 99.09842681884766
+      - 90.0
+      - 90.0
+      - 28.501245498657227
+      - 28.501245498657227
+      - 60.0
+      - 60.0
+      - 28.501245498657227
+      - 28.501245498657227
+      - 20.0
+      - 20.0
+      - 60.0
+      - 60.0
+      - 4.0
+      - 4.0
+      - 4.0
+      - 4.0
+      - 4.0
+      - 4.0
+    default_joint_friction:
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+    default_joint_armature:
+      - 0.010177520103752613
+      - 0.010177520103752613
+      - 0.029999999329447746
+      - 0.025101924315094948
+      - 0.025101924315094948
+      - 0.029999999329447746
+      - 0.010177520103752613
+      - 0.010177520103752613
+      - 0.029999999329447746
+      - 0.025101924315094948
+      - 0.025101924315094948
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.007219450082629919
+      - 0.007219450082629919
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.007219450082629919
+      - 0.007219450082629919
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+      - 0.029999999329447746
+scene:
+  physics_dt: 0.005
+  dt: 0.02
+  decimation: 4

--- a/agile/sim2mujoco/__init__.py
+++ b/agile/sim2mujoco/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Sim2MuJoCo Evaluation Module.
+
+A lightweight, self-contained module for evaluating RL policies in MuJoCo simulation.
+"""
+
+from .actions import ActionProcessor
+from .commands import CommandManager
+from .observations import ObservationProcessor
+from .policy import PolicyWrapper
+from .simulation import JointCommand, MuJocoSimulation, SimState
+from .utils import default_device, load_config
+
+__version__ = "1.0.0"
+
+__all__ = [
+    "PolicyWrapper",
+    "MuJocoSimulation",
+    "SimState",
+    "JointCommand",
+    "ObservationProcessor",
+    "ActionProcessor",
+    "CommandManager",
+    "load_config",
+    "default_device",
+]

--- a/agile/sim2mujoco/actions.py
+++ b/agile/sim2mujoco/actions.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Action processing."""
+
+import torch
+
+from agile.sim2mujoco.simulation import JointCommand
+
+
+class ActionTerm:
+    """Single action term (e.g., JointPositionAction)."""
+
+    def __init__(self, name: str, config: dict, full_joint_names: list[str], device: torch.device):
+        """
+        Initialize action term.
+
+        Args:
+            name: Name of the action term.
+            config: Configuration dictionary for this term.
+            full_joint_names: List of all joint names from simulation.
+            device: Torch device.
+        """
+        self.name = name
+        self.config = config
+        self.device = device
+
+        # Parse action configuration.
+        self.action_joint_names = config.get("joint_names", [])
+
+        # Convert scale to tensor if it's a list or nested list
+        scale_raw = config.get("scale", 1.0)
+        if isinstance(scale_raw, list | tuple):
+            # Flatten if nested (e.g., [[1, 2, 3]] -> [1, 2, 3])
+            if isinstance(scale_raw[0], list | tuple):
+                scale_raw = scale_raw[0]
+            self.scale = torch.tensor(scale_raw, device=device, dtype=torch.float32)
+        else:
+            self.scale = float(scale_raw)  # Keep as scalar if single value
+
+        self.offset_list = config.get("offset", [0.0] * len(self.action_joint_names))
+        self.offset = torch.tensor(self.offset_list, device=device, dtype=torch.float32)
+        self.clip = config.get("clip", None)
+
+        # Map action joints to full robot joint indices.
+        self.joint_indices = [full_joint_names.index(jn) for jn in self.action_joint_names]
+
+        # Action dimension.
+        self.action_dim = len(self.action_joint_names)
+
+    def process(self, actions: torch.Tensor) -> torch.Tensor:
+        """
+        Process raw actions to joint positions.
+
+        Args:
+            actions: Raw actions from policy, shape (action_dim,).
+
+        Returns:
+            Processed joint positions, shape (action_dim,).
+        """
+        # Apply clipping if specified.
+        if self.clip is not None:
+            if isinstance(self.clip[0], list):
+                # Per-joint clipping.
+                clip_min = torch.tensor([c[0] for c in self.clip], device=self.device, dtype=torch.float32)
+                clip_max = torch.tensor([c[1] for c in self.clip], device=self.device, dtype=torch.float32)
+                actions = torch.clamp(actions, clip_min, clip_max)
+            else:
+                # Uniform clipping.
+                actions = torch.clamp(actions, self.clip[0], self.clip[1])
+
+        # Apply scale and offset.
+        joint_positions = actions * self.scale + self.offset
+
+        return joint_positions
+
+
+class ActionProcessor:
+    """Flexible action processor that handles arbitrary action terms."""
+
+    def __init__(self, config: dict, joint_names: list[str], device: torch.device):
+        """
+        Initialize action processor.
+
+        Args:
+            config: Configuration dictionary from YAML.
+            joint_names: List of joint names from simulation.
+            device: Torch device.
+        """
+        self.device = device
+        self.joint_names = joint_names
+        self.num_joints = len(joint_names)
+
+        # Parse action terms from YAML.
+        self.action_terms = []
+        action_configs = config["actions"]
+
+        for action_config in action_configs:
+            term = ActionTerm(action_config["name"], action_config, joint_names, device)
+
+            # Validate joint ordering
+            if hasattr(term, "joint_indices") and term.joint_indices is not None:
+                # Verify joints exist and ordering is as expected
+                actual_joint_order = [joint_names[idx] for idx in term.joint_indices]
+                if actual_joint_order != term.action_joint_names:
+                    raise ValueError(
+                        f"❌ ERROR: Joint ordering mismatch for action term '{term.name}'!\n"
+                        f"   YAML specifies: {term.action_joint_names[:5]}...\n"
+                        f"   Mapping gives:  {actual_joint_order[:5]}...\n"
+                        f"   Joint names in YAML don't match MJCF."
+                    )
+
+            self.action_terms.append(term)
+
+        # Total action dimension.
+        self.total_action_dim = sum(term.action_dim for term in self.action_terms)
+
+        # Compute action ranges for slicing.
+        action_dims = [term.action_dim for term in self.action_terms]
+        action_cumsum = [0] + list(torch.cumsum(torch.tensor(action_dims), dim=0).tolist())
+        self.action_ranges = [(int(action_cumsum[i]), int(action_cumsum[i + 1])) for i in range(len(action_dims))]
+
+        # Load PD gains and default positions.
+        robot_config = config["articulations"]["robot"]
+        self.default_joint_pos = self._parse_joint_values(
+            robot_config["default_joint_pos"], robot_config["joint_names"], joint_names
+        )
+        self.kp = self._parse_joint_values(
+            robot_config["default_joint_stiffness"], robot_config["joint_names"], joint_names
+        )
+        self.kd = self._parse_joint_values(
+            robot_config["default_joint_damping"], robot_config["joint_names"], joint_names
+        )
+
+    def _parse_joint_values(
+        self, values: list, yaml_joint_names: list[str], mjcf_joint_names: list[str]
+    ) -> torch.Tensor:
+        """
+        Map joint values from YAML order to MJCF order.
+
+        Args:
+            values: List of values in YAML joint order.
+            yaml_joint_names: Joint names from YAML.
+            mjcf_joint_names: Joint names from MJCF (simulation).
+
+        Returns:
+            Tensor of values in MJCF order.
+        """
+        # Initialize with zeros.
+        result = torch.zeros(len(mjcf_joint_names), device=self.device, dtype=torch.float32)
+
+        # Map values.
+        for yaml_idx, joint_name in enumerate(yaml_joint_names):
+            if joint_name in mjcf_joint_names:
+                mjcf_idx = mjcf_joint_names.index(joint_name)
+                result[mjcf_idx] = values[yaml_idx]
+
+        return result
+
+    def process(self, actions: torch.Tensor) -> JointCommand:
+        """
+        Process policy actions to joint commands.
+
+        Args:
+            actions: Raw actions from policy, shape (total_action_dim,).
+
+        Returns:
+            JointCommand with positions, kp, kd for all joints.
+        """
+        # Start with zeros
+        joint_positions = torch.zeros_like(self.default_joint_pos)
+
+        # Apply each action term.
+        for term, (start, end) in zip(self.action_terms, self.action_ranges, strict=False):
+            action_slice = actions[start:end]
+            processed = term.process(action_slice)
+
+            # Write to appropriate joint indices.
+            joint_positions[term.joint_indices] = processed
+
+        return JointCommand(position=joint_positions, kp=self.kp, kd=self.kd)

--- a/agile/sim2mujoco/commands.py
+++ b/agile/sim2mujoco/commands.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command manager for interactive control of robot commands."""
+
+import threading
+
+import torch
+
+
+class CommandManager:
+    """
+    Thread-safe manager for velocity and height commands with keyboard control.
+
+    Command ranges:
+        - linear_x: [-0.5, 0.5] m/s
+        - linear_y: [-0.5, 0.5] m/s
+        - angular_z: [-1.0, 1.0] rad/s
+        - height: [0.3, 0.8] m
+    """
+
+    def __init__(self, device: torch.device, defaults: dict = None):
+        """
+        Initialize command manager.
+
+        Args:
+            device: Torch device for tensor creation.
+            defaults: Dictionary with default values for commands.
+        """
+        self.device = device
+
+        # Thread-safe lock (viewer runs in separate thread)
+        self._lock = threading.Lock()
+
+        # Default values
+        defaults = defaults or {}
+        self._default_linear_x = defaults.get("linear_x", 0.0)
+        self._default_linear_y = defaults.get("linear_y", 0.0)
+        self._default_angular_z = defaults.get("angular_z", 0.0)
+        self._default_height = defaults.get("height", 0.72)
+
+        # Current values
+        self._linear_x = self._default_linear_x
+        self._linear_y = self._default_linear_y
+        self._angular_z = self._default_angular_z
+        self._height = self._default_height
+
+        # Step sizes for incremental control
+        self.vel_step = 0.1  # m/s per key press
+        self.ang_step = 0.2  # rad/s per key press
+        self.height_step = 0.05  # m per key press
+
+        # Command limits
+        self.linear_x_range = (-0.5, 0.5)
+        self.linear_y_range = (-0.5, 0.5)
+        self.angular_z_range = (-1.0, 1.0)
+        self.height_range = (0.3, 0.8)
+
+    def _clamp(self, value: float, min_val: float, max_val: float) -> float:
+        """Clamp value to range."""
+        return max(min_val, min(max_val, value))
+
+    def update_linear_x(self, delta: float):
+        """Increment/decrement forward velocity."""
+        with self._lock:
+            self._linear_x = self._clamp(self._linear_x + delta, *self.linear_x_range)
+
+    def update_linear_y(self, delta: float):
+        """Increment/decrement sideways velocity."""
+        with self._lock:
+            self._linear_y = self._clamp(self._linear_y + delta, *self.linear_y_range)
+
+    def update_angular_z(self, delta: float):
+        """Increment/decrement turning velocity."""
+        with self._lock:
+            self._angular_z = self._clamp(self._angular_z + delta, *self.angular_z_range)
+
+    def update_height(self, delta: float):
+        """Increment/decrement target height."""
+        with self._lock:
+            self._height = self._clamp(self._height + delta, *self.height_range)
+
+    def stop(self):
+        """Reset all commands to default values (STOP button)."""
+        with self._lock:
+            self._linear_x = self._default_linear_x
+            self._linear_y = self._default_linear_y
+            self._angular_z = self._default_angular_z
+            self._height = self._default_height
+        print("🛑 STOP: All commands reset to defaults")
+        self.print_status()
+
+    def get_command(self) -> torch.Tensor:
+        """
+        Get current command as tensor.
+
+        Returns:
+            Tensor of shape (4,) with [vx, vy, wz, height].
+        """
+        with self._lock:
+            return torch.tensor(
+                [self._linear_x, self._linear_y, self._angular_z, self._height], device=self.device, dtype=torch.float32
+            )
+
+    def get_navigation_command(self) -> torch.Tensor:
+        """
+        Get navigation command (3D version without height).
+
+        Returns:
+            Tensor of shape (3,) with [vx, vy, wz].
+        """
+        with self._lock:
+            return torch.tensor(
+                [self._linear_x, self._linear_y, self._angular_z], device=self.device, dtype=torch.float32
+            )
+
+    def print_status(self):
+        """Print current command values."""
+        with self._lock:
+            print(
+                f"📡 Commands: "
+                f"vel_x={self._linear_x:+.2f} m/s, "
+                f"vel_y={self._linear_y:+.2f} m/s, "
+                f"ang_z={self._angular_z:+.2f} rad/s, "
+                f"height={self._height:.2f} m"
+            )

--- a/agile/sim2mujoco/observations.py
+++ b/agile/sim2mujoco/observations.py
@@ -1,0 +1,423 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Observation computation with history support."""
+
+import torch
+
+from agile.sim2mujoco.utils import quat_rotate_inverse
+
+
+class HistoryBuffer:
+    """Circular buffer for observation history."""
+
+    def __init__(self, obs_dim: int, history_length: int, device: torch.device):
+        """
+        Initialize history buffer.
+
+        Args:
+            obs_dim: Dimension of the observation.
+            history_length: Number of history steps (0 means no history).
+            device: Torch device.
+        """
+        self.history_length = history_length
+        self.obs_dim = obs_dim
+        self.device = device
+
+        if history_length > 0:
+            # Buffer shape: (history_length, obs_dim).
+            self.buffer = torch.zeros(history_length, obs_dim, device=device)
+            self.index = 0
+            self.filled = False
+        else:
+            self.buffer = None
+
+    def push(self, obs: torch.Tensor):
+        """Add new observation to history."""
+        if self.history_length == 0:
+            return
+
+        self.buffer[self.index] = obs
+        self.index = (self.index + 1) % self.history_length
+
+        if self.index == 0:
+            self.filled = True
+
+    def get(self, flatten: bool = True) -> torch.Tensor:
+        """
+        Get current history.
+
+        Returns:
+            If history_length == 0: returns None (should not be called).
+            If history_length > 0 and flatten: (history_length * obs_dim,).
+            If history_length > 0 and not flatten: (history_length, obs_dim).
+
+        Note:
+            Always returns the full history_length dimension, padding with zeros
+            if the buffer is not yet fully filled. This ensures consistent dimensions
+            for the policy from the very first step.
+        """
+        if self.history_length == 0:
+            raise ValueError("Cannot get history when history_length is 0")
+
+        # Always return full history_length dimension.
+        # Return in chronological order (oldest to newest).
+        if self.filled:
+            # Buffer is full, reorder to get chronological order
+            ordered = torch.cat([self.buffer[self.index :], self.buffer[: self.index]], dim=0)
+        else:
+            # Buffer not fully filled yet, return full buffer (zeros + filled entries)
+            # The buffer is already initialized with zeros, so unfilled entries are zero
+            ordered = self.buffer
+
+        if flatten:
+            return ordered.flatten()
+        else:
+            return ordered
+
+    def reset(self):
+        """Reset history buffer to zeros."""
+        if self.history_length > 0:
+            self.buffer.zero_()
+            self.index = 0
+            self.filled = False
+
+
+class ObservationTerm:
+    """Single observation term with history support."""
+
+    def __init__(self, name: str, config: dict, joint_names: list[str], device: torch.device):
+        """
+        Initialize observation term.
+
+        Args:
+            name: Name of the observation term.
+            config: Configuration dictionary for this term.
+            joint_names: List of all joint names from simulation.
+            device: Torch device.
+        """
+        self.name = name
+        self.config = config
+        self.device = device
+
+        # Parse overloads.
+        overloads = config.get("overloads", {})
+        self.history_length = overloads.get("history_length", 0)
+        self.flatten_history = overloads.get("flatten_history_dim", True)
+        self.clip = overloads.get("clip", None)
+        self.scale = overloads.get("scale", None)
+
+        # Determine observation dimension.
+        self.obs_dim = self._compute_obs_dim(config)
+
+        # Create history buffer.
+        self.history = HistoryBuffer(self.obs_dim, self.history_length, device)
+
+        # Store joint indices if needed.
+        if "joint_names" in config:
+            term_joint_names = config["joint_names"]
+            self.joint_names = term_joint_names  # Store for debugging/validation
+            self.joint_indices = [joint_names.index(jn) for jn in term_joint_names]
+
+            # Handle position offsets if present.
+            if "joint_pos_offsets" in config:
+                offsets = config["joint_pos_offsets"]
+                self.joint_offsets = torch.tensor(offsets, device=device, dtype=torch.float32)
+            else:
+                self.joint_offsets = None
+
+            # Handle velocity offsets if present.
+            if "joint_vel_offsets" in config:
+                vel_offsets = config["joint_vel_offsets"]
+                self.joint_vel_offsets = torch.tensor(vel_offsets, device=device, dtype=torch.float32)
+            else:
+                self.joint_vel_offsets = None
+        else:
+            self.joint_names = None
+            self.joint_indices = None
+            self.joint_offsets = None
+            self.joint_vel_offsets = None
+
+        # Compute function will be assigned by the factory.
+        self.compute_raw_fn = None
+
+    def _compute_obs_dim(self, config: dict) -> int:
+        """Compute the base observation dimension (without history)."""
+        shape = config.get("shape", [1])
+        if isinstance(shape, list):
+            return shape[0] if len(shape) == 1 else int(torch.prod(torch.tensor(shape)).item())
+        return shape
+
+    def compute(self, sim_state) -> torch.Tensor:
+        """
+        Compute observation with history, scaling, and clipping.
+
+        Args:
+            sim_state: Current simulation state.
+
+        Returns:
+            Tensor of shape (obs_dim,) if history_length == 0.
+            Tensor of shape (history_length * obs_dim,) if history_length > 0.
+        """
+        # Compute raw observation.
+        raw_obs = self.compute_raw_fn(sim_state)
+
+        # Apply scaling.
+        if self.scale is not None:
+            if isinstance(self.scale, list):
+                scale_tensor = torch.tensor(self.scale, device=self.device, dtype=torch.float32)
+                raw_obs = raw_obs * scale_tensor
+            else:
+                raw_obs = raw_obs * self.scale
+
+        # Apply clipping.
+        if self.clip is not None:
+            raw_obs = torch.clamp(raw_obs, self.clip[0], self.clip[1])
+
+        # Handle history.
+        if self.history_length == 0:
+            return raw_obs
+        else:
+            self.history.push(raw_obs)
+            return self.history.get(flatten=self.flatten_history)
+
+    def reset(self):
+        """Reset history buffer."""
+        self.history.reset()
+
+    def output_dim(self) -> int:
+        """Get the final output dimension (including history)."""
+        if self.history_length == 0:
+            return self.obs_dim
+        else:
+            return self.obs_dim * self.history_length
+
+
+class ObservationProcessor:
+    """Flexible observation processor that handles arbitrary observation terms."""
+
+    def __init__(self, config: dict, joint_names: list[str], device: torch.device, command_manager=None):
+        """
+        Initialize observation processor.
+
+        Args:
+            config: Configuration dictionary from YAML.
+            joint_names: List of joint names from simulation.
+            device: Torch device.
+            command_manager: Optional CommandManager for interactive commands.
+        """
+        self.device = device
+        self.joint_names = joint_names
+        self.command_manager = command_manager
+        self.terms = []
+
+        # Parse all observation terms from YAML.
+        obs_policy = config["observations"]["policy"]
+
+        for obs_config in obs_policy:
+            term_name = obs_config["name"]
+            expected_shape = obs_config.get("shape", [1])
+            base_dim = expected_shape[0] if isinstance(expected_shape, list) else expected_shape
+
+            # Account for history in expected dimension
+            overloads = obs_config.get("overloads", {})
+            history_length = overloads.get("history_length", 0)
+            if history_length > 0:
+                expected_dim = base_dim * history_length
+            else:
+                expected_dim = base_dim
+
+            # Create observation term.
+            term = self._create_term(term_name, obs_config, joint_names, device)
+
+            if term is None:
+                # Error instead of warning: unsupported observation term
+                raise ValueError(
+                    f"❌ ERROR: Unsupported observation term '{term_name}' found in config.\n"
+                    f"   Available terms: projected_gravity, base_ang_vel, base_lin_vel, "
+                    f"joint_pos_rel, joint_pos, joint_vel, joint_vel_rel, last_action, "
+                    f"navigation_command, locomotion_command, velocity_and_height_command, "
+                    f"generated_commands, zero_padding"
+                )
+
+            # Validate dimension matches expected shape from YAML (including history)
+            actual_dim = term.output_dim()
+            if actual_dim != expected_dim:
+                history_info = f" × history_length={history_length}" if history_length > 0 else ""
+                raise ValueError(
+                    f"❌ ERROR: Dimension mismatch for observation term '{term_name}'!\n"
+                    f"   Expected dimension: {expected_dim} (from YAML shape: {expected_shape}{history_info})\n"
+                    f"   Actual dimension:   {actual_dim}\n"
+                    f"   This may indicate a mismatch between the config and the robot model."
+                )
+
+            # Validate joint ordering for joint-based observations
+            if hasattr(term, "joint_indices") and term.joint_indices is not None:
+                if hasattr(term, "joint_names") and term.joint_names:
+                    # Verify that joint_indices maps correctly to joint_names
+                    actual_joint_order = [joint_names[idx] for idx in term.joint_indices]
+                    if actual_joint_order != term.joint_names:
+                        raise ValueError(
+                            f"❌ ERROR: Joint ordering mismatch for observation term '{term_name}'!\n"
+                            f"   YAML specifies these joints (in order): {term.joint_names[:5]}...\n"
+                            f"   But mapping produces this order:        {actual_joint_order[:5]}...\n"
+                            f"   This indicates the joint names in YAML don't match MJCF."
+                        )
+
+            self.terms.append(term)
+
+        # Compute total observation dimension.
+        self.total_obs_dim = sum(term.output_dim() for term in self.terms)
+
+        # Store last action for last_action terms.
+        self.last_action = None
+
+    def _create_term(self, name: str, config: dict, joint_names: list[str], device: torch.device) -> ObservationTerm:
+        """
+        Factory method to create observation terms.
+
+        Args:
+            name: Name of the observation term.
+            config: Configuration for the term.
+            joint_names: List of joint names.
+            device: Torch device.
+
+        Returns:
+            ObservationTerm instance or None if unknown.
+        """
+        # Create term.
+        term = ObservationTerm(name, config, joint_names, device)
+
+        # Assign compute function based on name.
+        if name == "projected_gravity":
+            term.compute_raw_fn = lambda sim_state: self._compute_projected_gravity(sim_state)
+        elif name == "base_ang_vel":
+            term.compute_raw_fn = lambda sim_state: self._compute_base_ang_vel(sim_state)
+        elif name == "base_lin_vel":
+            term.compute_raw_fn = lambda sim_state: self._compute_base_lin_vel(sim_state)
+        elif name == "joint_pos_rel":
+            term.compute_raw_fn = lambda sim_state: self._compute_joint_pos_rel(term, sim_state)
+        elif name == "joint_pos":
+            term.compute_raw_fn = lambda sim_state: self._compute_joint_pos(term, sim_state)
+        elif name == "joint_vel":
+            term.compute_raw_fn = lambda sim_state: self._compute_joint_vel(term, sim_state)
+        elif name == "joint_vel_rel":
+            term.compute_raw_fn = lambda sim_state: self._compute_joint_vel_rel(term, sim_state)
+        elif name == "last_action":
+            term.compute_raw_fn = lambda sim_state: self._compute_last_action(term)
+        elif name in ["navigation_command", "locomotion_command"]:
+            term.compute_raw_fn = lambda sim_state: self._compute_navigation_command()
+        elif name == "zero_padding":
+            term.compute_raw_fn = lambda sim_state: self._compute_zero_padding(term)
+        elif name in ["velocity_and_height_command", "generated_commands"]:
+            term.compute_raw_fn = lambda sim_state: self._compute_velocity_height_command()
+        else:
+            return None
+
+        return term
+
+    def _compute_projected_gravity(self, sim_state) -> torch.Tensor:
+        """Compute gravity vector in robot frame."""
+        gravity_world = torch.tensor([0.0, 0.0, -1.0], device=self.device, dtype=torch.float32)
+        # Rotate by inverse of root quaternion.
+        gravity_robot = quat_rotate_inverse(sim_state.root_quat.float(), gravity_world)
+        return gravity_robot
+
+    def _compute_base_ang_vel(self, sim_state) -> torch.Tensor:
+        """Compute base angular velocity."""
+        return sim_state.root_ang_vel.float()
+
+    def _compute_base_lin_vel(self, sim_state) -> torch.Tensor:
+        """Compute base linear velocity."""
+        return sim_state.root_lin_vel.float()
+
+    def _compute_joint_pos_rel(self, term: ObservationTerm, sim_state) -> torch.Tensor:
+        """Compute relative joint positions (with offsets).
+
+        Note: This should match IsaacLab's joint_pos_rel which computes:
+              joint_pos - default_joint_pos
+        The joint_offsets in the config should equal default_joint_pos for the controlled joints.
+        """
+        joint_pos = sim_state.joint_pos[term.joint_indices]
+        if term.joint_offsets is not None:
+            result = (joint_pos - term.joint_offsets).float()
+            return result
+        return joint_pos.float()
+
+    def _compute_joint_pos(self, term: ObservationTerm, sim_state) -> torch.Tensor:
+        """Compute absolute joint positions."""
+        return sim_state.joint_pos[term.joint_indices].float()
+
+    def _compute_joint_vel(self, term: ObservationTerm, sim_state) -> torch.Tensor:
+        """Compute joint velocities."""
+        return sim_state.joint_vel[term.joint_indices].float()
+
+    def _compute_joint_vel_rel(self, term: ObservationTerm, sim_state) -> torch.Tensor:
+        """Compute relative joint velocities (with offsets)."""
+        joint_vel = sim_state.joint_vel[term.joint_indices]
+        if term.joint_vel_offsets is not None:
+            return (joint_vel - term.joint_vel_offsets).float()
+        return joint_vel.float()
+
+    def _compute_last_action(self, term: ObservationTerm) -> torch.Tensor:
+        """Return last action."""
+        if self.last_action is None:
+            return torch.zeros(term.obs_dim, device=self.device, dtype=torch.float32)
+        return self.last_action.float()
+
+    def _compute_navigation_command(self) -> torch.Tensor:
+        """Return navigation command (3D: vx, vy, wz)."""
+        if self.command_manager is not None:
+            return self.command_manager.get_navigation_command()
+        # Fallback to zeros (backward compatibility)
+        return torch.zeros(3, device=self.device, dtype=torch.float32)
+
+    def _compute_velocity_height_command(self) -> torch.Tensor:
+        """4D command: [lin_vel_x, lin_vel_y, ang_vel_z, height]."""
+        if self.command_manager is not None:
+            return self.command_manager.get_command()
+        # Fallback to default (backward compatibility)
+        return torch.tensor([0.0, 0.0, 0.0, 0.72], device=self.device, dtype=torch.float32)
+
+    def _compute_zero_padding(self, term: ObservationTerm) -> torch.Tensor:
+        """Return zero padding."""
+        return torch.zeros(term.obs_dim, device=self.device, dtype=torch.float32)
+
+    def compute(self, sim_state) -> torch.Tensor:
+        """
+        Compute full observation vector.
+
+        Args:
+            sim_state: Current simulation state.
+
+        Returns:
+            Concatenated observation tensor of shape (total_obs_dim,).
+        """
+        obs_list = []
+        for term in self.terms:
+            obs = term.compute(sim_state)
+            obs_list.append(obs)
+
+        return torch.cat(obs_list, dim=0)
+
+    def set_last_action(self, action: torch.Tensor):
+        """Update last action for observation terms that need it."""
+        self.last_action = action
+
+    def reset(self):
+        """Reset all history buffers."""
+        for term in self.terms:
+            term.reset()
+        self.last_action = None

--- a/agile/sim2mujoco/policy.py
+++ b/agile/sim2mujoco/policy.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Policy loading and inference."""
+
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+class PolicyWrapper:
+    """Base wrapper for policy inference."""
+
+    def __init__(self, model: Any, device: torch.device):
+        """
+        Initialize policy wrapper.
+
+        Args:
+            model: Loaded model (torch.jit or onnxruntime session).
+            device: Device for inference.
+        """
+        self.model = model
+        self.device = device
+
+    def __call__(self, obs: torch.Tensor) -> torch.Tensor:
+        """
+        Run policy inference.
+
+        Args:
+            obs: Observation tensor.
+
+        Returns:
+            Action tensor.
+        """
+        raise NotImplementedError
+
+    def reset(self):
+        """Reset policy state (for RNN policies)."""
+        pass
+
+    @classmethod
+    def from_config(cls, checkpoint_path: Path, config: dict, device: torch.device) -> "PolicyWrapper":
+        """
+        Create policy wrapper from checkpoint and config.
+
+        Args:
+            checkpoint_path: Path to checkpoint file (.pt or .onnx).
+            config: Configuration dictionary.
+            device: Device for inference.
+
+        Returns:
+            Appropriate policy wrapper.
+        """
+        # Determine policy type from config.
+        policy_config = config.get("policy", {"type": "MLP"})
+        policy_type = policy_config.get("type", "MLP")
+
+        # Detect file type.
+        if checkpoint_path.suffix == ".onnx":
+            return ONNXPolicyWrapper.load(checkpoint_path, device)
+        else:
+            # Load PyTorch JIT model.
+            model = torch.jit.load(checkpoint_path, map_location=device)
+            model.eval()
+
+            if policy_type == "RNN":
+                hidden_shape = policy_config.get("hidden_shape", [2, 1, 128])
+                return RNNPolicyWrapper(model, hidden_shape, device)
+            else:
+                return MLPPolicyWrapper(model, device)
+
+
+class MLPPolicyWrapper(PolicyWrapper):
+    """Wrapper for MLP policies."""
+
+    def __call__(self, obs: torch.Tensor) -> torch.Tensor:
+        """
+        Run MLP inference.
+
+        Args:
+            obs: Observation tensor, shape (obs_dim,).
+
+        Returns:
+            Action tensor, shape (action_dim,).
+        """
+        with torch.no_grad():
+            return self.model(obs)
+
+
+class RNNPolicyWrapper(PolicyWrapper):
+    """Wrapper for RNN policies with hidden state management."""
+
+    def __init__(self, model: Any, hidden_shape: list[int], device: torch.device):
+        """
+        Initialize RNN policy wrapper.
+
+        Args:
+            model: Loaded RNN model.
+            hidden_shape: Shape of hidden state [num_layers, batch_size, hidden_dim].
+            device: Device for inference.
+        """
+        super().__init__(model, device)
+        self.hidden_shape = hidden_shape
+        self.hidden = torch.zeros(*hidden_shape, device=device)
+
+    def __call__(self, obs: torch.Tensor) -> torch.Tensor:
+        """
+        Run RNN inference with hidden state.
+
+        Args:
+            obs: Observation tensor, shape (obs_dim,).
+
+        Returns:
+            Action tensor, shape (action_dim,).
+        """
+        with torch.no_grad():
+            # Add batch dimension.
+            obs_batched = obs.unsqueeze(0)
+
+            # Forward pass.
+            output, self.hidden = self.model(obs_batched, self.hidden)
+
+            # Remove batch dimension.
+            return output.squeeze(0)
+
+    def reset(self):
+        """Reset hidden state to zeros."""
+        self.hidden = torch.zeros(*self.hidden_shape, device=self.device)
+
+
+class ONNXPolicyWrapper(PolicyWrapper):
+    """Wrapper for ONNX policies."""
+
+    def __init__(self, session: Any, device: torch.device):
+        """
+        Initialize ONNX policy wrapper.
+
+        Args:
+            session: ONNX runtime inference session.
+            device: Device for inference (note: ONNX handles its own device placement).
+        """
+        super().__init__(session, device)
+        self.input_name = session.get_inputs()[0].name
+        self.output_name = session.get_outputs()[0].name
+
+    def __call__(self, obs: torch.Tensor) -> torch.Tensor:
+        """
+        Run ONNX inference.
+
+        Args:
+            obs: Observation tensor, shape (obs_dim,).
+
+        Returns:
+            Action tensor, shape (action_dim,).
+        """
+        # Convert to numpy.
+        obs_numpy = obs.cpu().numpy()
+
+        # Add batch dimension if needed.
+        if obs_numpy.ndim == 1:
+            obs_numpy = obs_numpy[None, :]
+
+        # Run inference.
+        outputs = self.model.run([self.output_name], {self.input_name: obs_numpy})
+
+        # Convert back to torch and remove batch dimension.
+        action = torch.from_numpy(outputs[0]).to(self.device).squeeze(0)
+
+        return action
+
+    @classmethod
+    def load(cls, checkpoint_path: Path, device: torch.device) -> "ONNXPolicyWrapper":
+        """
+        Load ONNX model.
+
+        Args:
+            checkpoint_path: Path to .onnx file.
+            device: Device for inference.
+
+        Returns:
+            ONNXPolicyWrapper instance.
+        """
+        import onnxruntime as ort
+
+        # Set execution providers.
+        providers = ["CUDAExecutionProvider"] if device.type == "cuda" else ["CPUExecutionProvider"]
+
+        # Create session.
+        session = ort.InferenceSession(str(checkpoint_path), providers=providers)
+
+        return cls(session, device)

--- a/agile/sim2mujoco/simulation.py
+++ b/agile/sim2mujoco/simulation.py
@@ -1,0 +1,444 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MuJoCo simulation wrapper."""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import mujoco
+import mujoco.viewer
+import torch
+
+
+@dataclass
+class SimState:
+    """State of the simulation."""
+
+    joint_pos: torch.Tensor
+    """Joint positions, shape (num_joints,)."""
+    joint_vel: torch.Tensor
+    """Joint velocities, shape (num_joints,)."""
+    root_pos: torch.Tensor
+    """Root position in world frame, shape (3,)."""
+    root_quat: torch.Tensor
+    """Root orientation quaternion [w, x, y, z], shape (4,)."""
+    root_lin_vel: torch.Tensor
+    """Root linear velocity in root frame, shape (3,)."""
+    root_ang_vel: torch.Tensor
+    """Root angular velocity in root frame, shape (3,)."""
+    joint_effort: torch.Tensor | None = None
+    """Joint efforts/torques, shape (num_joints,). Optional."""
+
+
+@dataclass
+class JointCommand:
+    """Joint command with PD control parameters."""
+
+    position: torch.Tensor
+    """Desired joint positions, shape (num_joints,)."""
+    kp: torch.Tensor
+    """Proportional gains, shape (num_joints,)."""
+    kd: torch.Tensor
+    """Derivative gains, shape (num_joints,)."""
+
+
+class DummyViewer:
+    """Dummy viewer for headless operation."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def sync(self):
+        pass
+
+
+class MuJocoSimulation:
+    """MuJoCo simulation wrapper."""
+
+    def __init__(
+        self,
+        config: dict,
+        device: torch.device,
+        enable_viewer: bool = True,
+        mjcf_path: Path | None = None,
+        command_manager=None,
+    ):
+        """
+        Initialize MuJoCo simulation.
+
+        Args:
+            config: Configuration dictionary from YAML.
+            device: Device for torch tensors.
+            enable_viewer: Whether to enable the viewer.
+            mjcf_path: Path to MJCF file (overrides config).
+            command_manager: Optional CommandManager for interactive control.
+        """
+        self.device = device
+        self.config = config
+        self.command_manager = command_manager
+
+        # Get MJCF path.
+        if mjcf_path is not None:
+            self.mjcf_path = mjcf_path
+        elif "mjcf_path" in config:
+            self.mjcf_path = Path(config["mjcf_path"])
+        else:
+            raise ValueError("MJCF path must be provided via config or argument")
+
+        # Load MuJoCo model.
+        print(f"Loading MJCF from: {self.mjcf_path}")
+        self.mj_model = mujoco.MjModel.from_xml_path(str(self.mjcf_path))
+        self.mj_data = mujoco.MjData(self.mj_model)
+
+        # Set timestep from config.
+        scene_config = config.get("scene", {})
+
+        # Use physics_dt if available, otherwise fall back to dt
+        if "physics_dt" in scene_config:
+            self.mj_model.opt.timestep = scene_config["physics_dt"]
+        elif "dt" in scene_config:
+            # If only dt is provided, assume it's the physics timestep
+            self.mj_model.opt.timestep = scene_config["dt"]
+
+        self.physics_dt = self.mj_model.opt.timestep
+        self.decimation = scene_config.get("decimation", 4)
+
+        # Control dt is physics_dt * decimation
+        self.dt = self.physics_dt * self.decimation
+
+        # Extract joint names (skip freejoint if present).
+        self.joint_names = []
+        for i in range(self.mj_model.njnt):
+            joint_type = self.mj_model.jnt_type[i]
+            if joint_type != mujoco.mjtJoint.mjJNT_FREE:  # Skip freejoint.
+                joint_name = mujoco.mj_id2name(self.mj_model, mujoco.mjtObj.mjOBJ_JOINT, i)
+                self.joint_names.append(joint_name)
+
+        self.num_joints = len(self.joint_names)
+        print(f"Found {self.num_joints} actuated joints: {self.joint_names}")
+
+        # Determine if fixed base.
+        self.fixed_base = not self._has_freejoint()
+
+        # Detect actuator type.
+        self._detect_actuator_type()
+
+        # Create mapping from joint names to actuator/control indices.
+        # This matches isaac-deploy's _joint_to_ctrl_indices implementation.
+        # The actuators in MuJoCo might be in different order than joints.
+        self._joint_to_ctrl_indices = []
+        for joint_name in self.joint_names:
+            # Find the actuator index that controls this joint.
+            for i in range(self.mj_model.nu):
+                actuator_joint_id = self.mj_model.actuator_trnid[i, 0]
+                if actuator_joint_id >= 0:  # Valid joint actuator.
+                    actuator_joint_name = mujoco.mj_id2name(self.mj_model, mujoco.mjtObj.mjOBJ_JOINT, actuator_joint_id)
+                    if actuator_joint_name == joint_name:
+                        self._joint_to_ctrl_indices.append(i)
+                        break
+
+        if len(self._joint_to_ctrl_indices) != self.num_joints:
+            print(
+                f"Warning: Found {len(self._joint_to_ctrl_indices)} actuators "
+                f"for {self.num_joints} joints. Some joints may not be actuated."
+            )
+
+        print(f"  Joint to actuator mapping: {self._joint_to_ctrl_indices}")
+
+        # Setup viewer.
+        if enable_viewer and "DISPLAY" in os.environ:
+            self.viewer = mujoco.viewer.launch_passive(
+                self.mj_model, self.mj_data, key_callback=self._key_callback if command_manager else None
+            )
+            # Configure camera.
+            with self.viewer.lock():
+                self.viewer.cam.lookat[:] = [0, 0, 1.0]
+                self.viewer.cam.distance = 3.0
+                self.viewer.cam.azimuth = 135.0
+                self.viewer.cam.elevation = -20.0
+
+            # Print keyboard controls if command manager is active
+            if self.command_manager is not None:
+                self._print_keyboard_help()
+        else:
+            self.viewer = DummyViewer()
+            self.viewer.__enter__()
+
+        # Setup velocity sensors.
+        self._setup_sensors()
+
+        # Set initial configuration.
+        self._set_initial_configuration(config)
+
+    def _has_freejoint(self) -> bool:
+        """Check if model has a freejoint (floating base)."""
+        for i in range(self.mj_model.njnt):
+            if self.mj_model.jnt_type[i] == mujoco.mjtJoint.mjJNT_FREE:
+                return True
+        return False
+
+    def _world_to_root_frame(self, world_vec: torch.Tensor, root_quat: torch.Tensor) -> torch.Tensor:
+        """
+        Transform a vector from world frame to root frame.
+
+        Args:
+            world_vec: Vector in world frame, shape (3,).
+            root_quat: Root orientation quaternion [w, x, y, z], shape (4,).
+
+        Returns:
+            Vector in root frame, shape (3,).
+        """
+        # Import the function from utils.
+        from agile.sim2mujoco.utils import quat_rotate_inverse
+
+        return quat_rotate_inverse(root_quat, world_vec)
+
+    def _detect_actuator_type(self):
+        """
+        Detect actuator type from MuJoCo model.
+
+        Actuators can be:
+        - 'position': Built-in PD control (biastype == 1)
+        - 'torque': Direct torque control (biastype == 0)
+        """
+        if self.mj_model.nu == 0:
+            self.actuator_type = "torque"
+            return
+
+        # Check bias types.
+        actuator_bias_types = [self.mj_model.actuator(i).biastype for i in range(self.mj_model.nu)]
+
+        # Verify all actuators have the same type.
+        if not all(bias_type == actuator_bias_types[0] for bias_type in actuator_bias_types):
+            print("Warning: Mixed actuator types detected, using first type")
+
+        if actuator_bias_types[0] == 0:  # Bias: None -> Torque mode.
+            self.actuator_type = "torque"
+        elif actuator_bias_types[0] == 1:  # Bias: Affine -> Position mode with PD.
+            self.actuator_type = "position"
+        else:
+            print(f"Warning: Unknown actuator bias type {actuator_bias_types[0]}, defaulting to torque")
+            self.actuator_type = "torque"
+
+        print(f"  Actuator type: {self.actuator_type}")
+
+    def _setup_sensors(self):
+        """Setup velocity sensors - matching isaac-deploy implementation."""
+        # Initialize sensors to None.
+        self._root_linear_velocity_sensor = None
+        self._root_angular_velocity_sensor = None
+        self._root_linear_acceleration_sensor = None
+
+        # Try to find sensors by name (matching isaac-deploy naming).
+        try:
+            self._root_linear_velocity_sensor = self.mj_data.sensor("linear-velocity")
+        except KeyError:
+            print("Warning: 'linear-velocity' sensor not found, will compute from qvel")
+
+        try:
+            self._root_angular_velocity_sensor = self.mj_data.sensor("angular-velocity")
+        except KeyError:
+            print("Warning: 'angular-velocity' sensor not found, will compute from qvel")
+
+        try:
+            self._root_linear_acceleration_sensor = self.mj_data.sensor("linear-acceleration")
+        except KeyError:
+            print("Warning: 'linear-acceleration' sensor not found")
+
+    def _set_initial_configuration(self, config: dict):
+        """Set initial joint positions from config."""
+        # Set default root position for floating base robots.
+        if not self.fixed_base:
+            self.mj_model.qpos0[:3] = [0.0, 0.0, 0.9]
+            self.mj_model.qpos0[3:7] = [1.0, 0.0, 0.0, 0.0]
+
+    def reset(self):
+        """Reset simulation to initial state."""
+        mujoco.mj_resetData(self.mj_model, self.mj_data)
+        self.mj_data.ctrl[:] = 0
+        # Forward kinematics to compute derived quantities.
+        mujoco.mj_forward(self.mj_model, self.mj_data)
+
+    def get_state(self) -> SimState:
+        """
+        Get current simulation state.
+
+        Returns:
+            SimState object with current state.
+        """
+        if self.fixed_base:
+            # Fixed base robot.
+            joint_pos = torch.from_numpy(self.mj_data.qpos.copy()).to(self.device)
+            joint_vel = torch.from_numpy(self.mj_data.qvel.copy()).to(self.device)
+            root_pos = torch.zeros(3, device=self.device)
+            root_quat = torch.tensor([1.0, 0.0, 0.0, 0.0], device=self.device)
+            root_lin_vel = torch.zeros(3, device=self.device)
+            root_ang_vel = torch.zeros(3, device=self.device)
+        else:
+            # Floating base robot.
+            root_pos = torch.from_numpy(self.mj_data.qpos[:3].copy()).to(self.device)
+            root_quat = torch.from_numpy(self.mj_data.qpos[3:7].copy()).to(self.device)
+            joint_pos = torch.from_numpy(self.mj_data.qpos[7:].copy()).to(self.device)
+
+            joint_vel = torch.from_numpy(self.mj_data.qvel[6:].copy()).to(self.device)
+
+            # Get velocities from sensors (matching isaac-deploy implementation).
+            # Sensors provide velocities in root frame directly from MuJoCo.
+            if self._root_linear_velocity_sensor is not None:
+                root_lin_vel = torch.from_numpy(self._root_linear_velocity_sensor.data.copy()).to(self.device)
+            else:
+                # Fallback: Convert world frame velocity to root frame.
+                world_lin_vel = torch.from_numpy(self.mj_data.qvel[:3].copy()).to(self.device)
+                root_lin_vel = self._world_to_root_frame(world_lin_vel, root_quat)
+
+            if self._root_angular_velocity_sensor is not None:
+                root_ang_vel = torch.from_numpy(self._root_angular_velocity_sensor.data.copy()).to(self.device)
+            else:
+                # Fallback: Convert world frame angular velocity to root frame.
+                world_ang_vel = torch.from_numpy(self.mj_data.qvel[3:6].copy()).to(self.device)
+                root_ang_vel = self._world_to_root_frame(world_ang_vel, root_quat)
+
+        return SimState(
+            joint_pos=joint_pos,
+            joint_vel=joint_vel,
+            root_pos=root_pos,
+            root_quat=root_quat,
+            root_lin_vel=root_lin_vel,
+            root_ang_vel=root_ang_vel,
+            joint_effort=None,  # Populated during control if needed.
+        )
+
+    def step(self, joint_cmd: JointCommand):
+        """
+        Step the simulation with joint commands.
+
+        Args:
+            joint_cmd: Joint command with positions and PD gains.
+        """
+        if self.actuator_type == "position":
+            # Position actuators: MuJoCo handles PD control internally.
+            # Map joint order to actuator order (matching isaac-deploy).
+            joint_positions_np = joint_cmd.position.cpu().numpy()
+            joint_kp_np = joint_cmd.kp.cpu().numpy()
+            joint_kd_np = joint_cmd.kd.cpu().numpy()
+
+            # Set target positions in actuator order.
+            self.mj_data.ctrl[:] = joint_positions_np[self._joint_to_ctrl_indices]
+
+            # Update PD gains in actuator parameters.
+            # See: https://mujoco.readthedocs.io/en/stable/XMLreference.html#actuator-position
+            self.mj_model.actuator_gainprm[:, 0] = joint_kp_np[self._joint_to_ctrl_indices]
+            self.mj_model.actuator_biasprm[:, 1] = -joint_kp_np[self._joint_to_ctrl_indices]
+            self.mj_model.actuator_biasprm[:, 2] = -joint_kd_np[self._joint_to_ctrl_indices]
+
+        else:  # torque mode
+            # Torque actuators: Compute torques manually.
+            state = self.get_state()
+
+            pos_error = joint_cmd.position - state.joint_pos
+            vel_error = -state.joint_vel  # Assuming zero target velocity.
+
+            torques = joint_cmd.kp * pos_error + joint_cmd.kd * vel_error
+
+            # Store computed torques in state (matching isaac-deploy line 349).
+            state.joint_effort = torques
+
+            # Map joint order to actuator order (matching isaac-deploy line 350).
+            self.mj_data.ctrl[:] = torques[self._joint_to_ctrl_indices].cpu().numpy()
+
+        # Step simulation.
+        mujoco.mj_step(self.mj_model, self.mj_data)
+
+        # Update viewer.
+        self.viewer.sync()
+
+    def close(self):
+        """Close simulation and viewer."""
+        if hasattr(self.viewer, "__exit__"):
+            self.viewer.__exit__(None, None, None)
+
+    def _key_callback(self, key: int):
+        """
+        Keyboard callback for command control.
+
+        Args:
+            key: GLFW key code.
+        """
+        if self.command_manager is None:
+            return
+
+        import glfw
+
+        # Forward/Backward (Arrow Up/Down or I/K)
+        if key == glfw.KEY_UP or key == glfw.KEY_I:
+            self.command_manager.update_linear_x(self.command_manager.vel_step)
+            self.command_manager.print_status()
+        elif key == glfw.KEY_DOWN or key == glfw.KEY_K:
+            self.command_manager.update_linear_x(-self.command_manager.vel_step)
+            self.command_manager.print_status()
+
+        # Left/Right strafe (Arrow Left/Right or J/L)
+        elif key == glfw.KEY_LEFT or key == glfw.KEY_J:
+            self.command_manager.update_linear_y(self.command_manager.vel_step)
+            self.command_manager.print_status()
+        elif key == glfw.KEY_RIGHT or key == glfw.KEY_L:
+            self.command_manager.update_linear_y(-self.command_manager.vel_step)
+            self.command_manager.print_status()
+
+        # Turn Left/Right (U/O)
+        elif key == glfw.KEY_U:
+            self.command_manager.update_angular_z(self.command_manager.ang_step)
+            self.command_manager.print_status()
+        elif key == glfw.KEY_O:
+            self.command_manager.update_angular_z(-self.command_manager.ang_step)
+            self.command_manager.print_status()
+
+        # Height Up/Down (Page Up/Down or 9/0 on number row)
+        elif key == glfw.KEY_PAGE_UP or key == glfw.KEY_9:
+            self.command_manager.update_height(self.command_manager.height_step)
+            self.command_manager.print_status()
+        elif key == glfw.KEY_PAGE_DOWN or key == glfw.KEY_0:
+            self.command_manager.update_height(-self.command_manager.height_step)
+            self.command_manager.print_status()
+
+        # STOP - Reset to defaults (SPACE or H for "Home")
+        elif key == glfw.KEY_SPACE or key == glfw.KEY_H:
+            self.command_manager.stop()
+
+        # Print status (P)
+        elif key == glfw.KEY_P:
+            self.command_manager.print_status()
+
+    def _print_keyboard_help(self):
+        """Print keyboard control instructions."""
+        print("\n" + "=" * 80)
+        print("⌨️  KEYBOARD CONTROLS (Interactive Command Mode)")
+        print("=" * 80)
+        print("  ⚠️  NOTE: Click on the MuJoCo viewer window to enable keyboard input!")
+        print("=" * 80)
+        print("  ↑ / I     or  ↓ / K      : Forward / Backward    (±0.1 m/s,   [-0.5, 0.5])")
+        print("  ← / J     or  → / L      : Left / Right strafe   (±0.1 m/s,   [-0.5, 0.5])")
+        print("  U         or  O          : Turn Left / Right     (±0.2 rad/s, [-1.0, 1.0])")
+        print("  PgUp / 9  or  PgDn / 0   : Height Up / Down      (±0.05 m,    [0.3, 0.8])")
+        print("  SPACE / H                : STOP (reset to 0.0, 0.0, 0.0, 0.72)")
+        print("  P                        : Print current status")
+        print("=" * 80)
+        print("  💡 Use Arrow Keys for easy control, or I/J/K/L (vim-style)")
+        print("=" * 80 + "\n")

--- a/agile/sim2mujoco/utils.py
+++ b/agile/sim2mujoco/utils.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for sim2mujoco evaluation."""
+
+from pathlib import Path
+
+import torch
+import yaml
+
+
+def quat_rotate_inverse(q: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    """
+    Rotate a vector by the inverse of a quaternion.
+
+    Uses the EXACT same implementation as isaac-deploy (core/math/geometry.py:624).
+    This ensures numerical consistency.
+
+    Args:
+        q: Quaternion [w, x, y, z], shape (4,)
+        v: Vector to rotate, shape (3,)
+
+    Returns:
+        Rotated vector, shape (3,)
+    """
+    # Extract quaternion components.
+    q_w = q[0]
+    q_vec = q[1:]
+
+    # Apply the inverse rotation formula (matching isaac-deploy exactly).
+    # v' = v * (2*w^2 - 1) - 2*w*(q_vec x v) + 2*(q_vec · v)*q_vec
+    a = v * (2.0 * q_w**2 - 1.0)
+    b = torch.cross(q_vec, v, dim=0) * q_w * 2.0
+    c = q_vec * torch.dot(q_vec, v) * 2.0
+
+    return a - b + c
+
+
+def quat_inv(q: torch.Tensor) -> torch.Tensor:
+    """
+    Compute the inverse (conjugate) of a quaternion.
+
+    Args:
+        q: Quaternion [w, x, y, z], shape (4,)
+
+    Returns:
+        Inverse quaternion [w, -x, -y, -z], shape (4,)
+    """
+    return torch.tensor([q[0], -q[1], -q[2], -q[3]], device=q.device, dtype=q.dtype)
+
+
+def quat_apply(q: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+    """
+    Apply a quaternion rotation to a vector.
+
+    Uses the cross-product formula matching isaac-deploy (core/math/geometry.py:559).
+
+    Args:
+        q: Quaternion [w, x, y, z], shape (4,)
+        v: Vector to rotate, shape (3,)
+
+    Returns:
+        Rotated vector, shape (3,)
+    """
+    # Extract quaternion vector part.
+    q_w = q[0]
+    q_vec = q[1:]
+
+    # Cross-product formula: v' = v + 2*w*(q_vec × v) + 2*(q_vec × (q_vec × v))
+    t = torch.cross(q_vec, v, dim=0) * 2.0
+    return v + q_w * t + torch.cross(q_vec, t, dim=0)
+
+
+def load_config(yaml_path: Path) -> dict:
+    """
+    Load YAML configuration file.
+
+    Args:
+        yaml_path: Path to YAML file.
+
+    Returns:
+        Dictionary containing configuration.
+    """
+    with open(yaml_path) as f:
+        return yaml.safe_load(f)
+
+
+def default_device() -> torch.device:
+    """
+    Get default device (CUDA if available, else CPU).
+
+    Returns:
+        torch.device object.
+    """
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     # Extra dependencies (requirements-extras.txt)
     "datasets==2.19.0",
     "dearpygui==2.1.0",
+    # Sim2Mujoco dependencies
+    "mujoco>=3.3.6",
 ]
 
 [project.optional-dependencies]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,46 @@ Example usage:
 python scripts/play.py --task Velocity-T1-v0 --num_envs 32
 ```
 
+### `sim2mujoco_eval.py`
+Evaluation script for Sim2Sim transfer to MuJoCo. Runs trained policies in MuJoCo simulation to verify transfer performance before real hardware deployment. This is a **generic framework** that works with any task by automatically parsing the I/O descriptor YAML file.
+
+Example usage:
+```bash
+python scripts/sim2mujoco_eval.py --checkpoint path/to/policy.pt --config path/to/config.yaml --mjcf path/to/robot.xml
+```
+
+**Quick Start Tutorial:**
+
+1. **Export Policy to TorchScript:**
+   ```bash
+   python scripts/eval.py --task Velocity-G1-History-v0 --checkpoint path/to/checkpoint.pt
+   # This automatically exports policy.pt in the checkpoint directory's exported/ folder
+   ```
+
+2. **Export I/O Descriptors:**
+   ```bash
+   python scripts/export_IODescriptors.py --task Velocity-G1-History-v0 --output_dir path/to/output
+   # Generates a YAML file describing observation/action spaces
+   ```
+
+3. **Get Robot MJCF:**
+   We recommend using official robot models from [Unitree's MuJoCo repository](https://github.com/unitreerobotics/unitree_mujoco):
+   ```bash
+   git clone https://github.com/unitreerobotics/unitree_mujoco.git
+   # G1 robot: unitree_mujoco/unitree_robots/g1/g1_29dof.xml
+   ```
+
+4. **Run Sim2MuJoCo Evaluation:**
+   ```bash
+   python scripts/sim2mujoco_eval.py \
+     --checkpoint path/to/policy.pt \
+     --config path/to/config.yaml \
+     --mjcf unitree_mujoco/unitree_robots/g1/scene_29dof.xml \
+     --duration 10.0
+   ```
+
+> **💡 Interactive Control:** The sim2mujoco module supports keyboard teleoperation. Use arrow keys (↑↓←→) or I/J/K/L for movement, U/O for turning, and Page Up/Down (or 9/0) for height control. Press SPACE to stop. Remove `--no-viewer` flag to enable the interactive viewer.
+
 ## Utility Scripts
 
 

--- a/scripts/play.py
+++ b/scripts/play.py
@@ -161,7 +161,7 @@ def main() -> None:
 
     # Get action space dimensions
     num_envs = env.unwrapped.num_envs
-    action_dim = int(np.prod(env.action_space.shape))
+    action_dim = env.unwrapped.action_manager.total_action_dim
 
     print(f"[INFO] Environment loaded: {args_cli.task}")
     print(f"[INFO] Number of environments: {num_envs}")

--- a/scripts/sim2mujoco_eval.py
+++ b/scripts/sim2mujoco_eval.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Main entry point for sim2mujoco evaluation."""
+
+import argparse
+from pathlib import Path
+
+import torch
+
+from agile.sim2mujoco.actions import ActionProcessor
+from agile.sim2mujoco.commands import CommandManager
+from agile.sim2mujoco.observations import ObservationProcessor
+from agile.sim2mujoco.policy import PolicyWrapper
+from agile.sim2mujoco.simulation import MuJocoSimulation
+from agile.sim2mujoco.utils import default_device, load_config
+
+
+def main():
+    """Run sim2sim evaluation."""
+    parser = argparse.ArgumentParser(description="Sim2Sim Policy Evaluation")
+    parser.add_argument("--checkpoint", type=Path, required=True, help="Path to policy checkpoint (.pt or .onnx)")
+    parser.add_argument("--config", type=Path, required=True, help="Path to YAML config")
+    parser.add_argument("--mjcf", type=Path, default=None, help="Path to MJCF file (optional, overrides config)")
+    parser.add_argument("--duration", type=float, default=10.0, help="Simulation duration (seconds)")
+    parser.add_argument("--device", type=str, default="auto", help="Device: cuda, cpu, or auto")
+    parser.add_argument("--no-viewer", action="store_true", help="Disable MuJoCo viewer")
+    parser.add_argument("--log-freq", type=int, default=100, help="Logging frequency (control steps)")
+    parser.add_argument(
+        "--pd-scale", type=float, default=1.0, help="Scale factor for PD gains (use 0.3-0.5 for stability)"
+    )
+    parser.add_argument(
+        "--disable-keyboard", action="store_true", help="Disable keyboard control for interactive commands"
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable step-by-step logging output")
+
+    args = parser.parse_args()
+
+    # Setup device.
+    if args.device == "auto":
+        device = default_device()
+    else:
+        device = torch.device(args.device)
+
+    print(f"Using device: {device}")
+
+    # Load config.
+    print(f"\nLoading config from {args.config}...")
+    config = load_config(args.config)
+
+    # Override MJCF path if provided.
+    if args.mjcf:
+        config["mjcf_path"] = str(args.mjcf)
+
+    # Scale PD gains if requested.
+    if args.pd_scale != 1.0:
+        print(f"Scaling PD gains by {args.pd_scale}...")
+        robot_config = config["articulations"]["robot"]
+        robot_config["default_joint_stiffness"] = [kp * args.pd_scale for kp in robot_config["default_joint_stiffness"]]
+        robot_config["default_joint_damping"] = [kd * args.pd_scale for kd in robot_config["default_joint_damping"]]
+
+    # Create command manager if keyboard control is enabled.
+    command_manager = None
+    if not args.disable_keyboard and not args.no_viewer:
+        command_manager = CommandManager(
+            device=device, defaults={"linear_x": 0.0, "linear_y": 0.0, "angular_z": 0.0, "height": 0.72}
+        )
+        print("\n✓ Keyboard control enabled")
+    else:
+        print("\n✓ Keyboard control disabled")
+
+    # Load policy.
+    print(f"\nLoading policy from {args.checkpoint}...")
+    policy = PolicyWrapper.from_config(args.checkpoint, config, device)
+    print(f"  Policy type: {type(policy).__name__}")
+
+    # Create simulation.
+    print("\nCreating simulation...")
+    sim = MuJocoSimulation(
+        config, device, enable_viewer=not args.no_viewer, mjcf_path=args.mjcf, command_manager=command_manager
+    )
+    print(f"  Num joints: {sim.num_joints}")
+    print(f"  Fixed base: {sim.fixed_base}")
+    print(f"  Physics dt: {sim.physics_dt}s ({1.0 / sim.physics_dt:.0f} Hz)")
+    print(f"  Control dt: {sim.dt}s ({1.0 / sim.dt:.1f} Hz)")
+    print(f"  Decimation: {sim.decimation}")
+
+    # Create processors.
+    print("\nSetting up observation processor...")
+    obs_processor = ObservationProcessor(config, sim.joint_names, device, command_manager=command_manager)
+    print(f"  Total observation dim: {obs_processor.total_obs_dim}")
+    print("  Observation terms:")
+    for term in obs_processor.terms:
+        hist_info = f" (history={term.history_length})" if term.history_length > 0 else ""
+        print(f"    - {term.name}: {term.output_dim()}{hist_info}")
+
+    print("\nSetting up action processor...")
+    act_processor = ActionProcessor(config, sim.joint_names, device)
+    print(f"  Total action dim: {act_processor.total_action_dim}")
+    print("  Action terms:")
+    for term in act_processor.action_terms:
+        print(f"    - {term.name}: {term.action_dim} joints (scale: {term.scale})")
+
+    # Reset.
+    sim.reset()
+    obs_processor.reset()
+    policy.reset()
+
+    # Evaluation loop.
+    control_dt = sim.dt  # This is physics_dt * decimation
+    physics_dt = sim.physics_dt
+    num_steps = int(args.duration / control_dt)
+
+    print(f"\nRunning evaluation for {args.duration}s ({num_steps} control steps)...")
+    print(f"  Control frequency: {1.0 / control_dt:.1f} Hz")
+    print(f"  Physics frequency: {1.0 / physics_dt:.1f} Hz")
+    print("-" * 80)
+
+    try:
+        for step in range(num_steps):
+            # Get observations.
+            sim_state = sim.get_state()
+            obs = obs_processor.compute(sim_state)
+
+            # Policy inference.
+            with torch.no_grad():
+                actions = policy(obs)
+
+            # Update last action.
+            obs_processor.set_last_action(actions)
+
+            # Process actions.
+            joint_cmd = act_processor.process(actions)
+
+            # Step simulation (decimation times).
+            for _ in range(sim.decimation):
+                sim.step(joint_cmd)
+
+            # Logging (get fresh state AFTER simulation steps).
+            if args.verbose and step % args.log_freq == 0:
+                current_state = sim.get_state()
+                print(
+                    f"Step {step:4d}/{num_steps} | "
+                    f"Root pos: [{current_state.root_pos[0]:6.3f}, {current_state.root_pos[1]:6.3f}, {current_state.root_pos[2]:6.3f}] | "
+                    f"Root vel: [{current_state.root_lin_vel[0]:6.3f}, {current_state.root_lin_vel[1]:6.3f}, {current_state.root_lin_vel[2]:6.3f}] | "
+                    f"Action mean: {actions.mean().item():7.4f}, std: {actions.std().item():7.4f}"
+                )
+
+        print("-" * 80)
+        print(f"\nEvaluation complete! Ran {num_steps} steps.")
+
+    except KeyboardInterrupt:
+        print("\n\nInterrupted by user.")
+
+    finally:
+        sim.close()
+        print("Simulation closed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/run_unit_tests.sh
+++ b/tests/run_unit_tests.sh
@@ -97,6 +97,7 @@ fi
 # Define fixed list of test files to exclude (E2E tests)
 ALWAYS_EXCLUDE=(
     "tests/test_all_tasks_e2e.py"
+    "tests/test_sim2mujoco_e2e.py"
 )
 
 # Combine the fixed exclusion list with command-line exclusions

--- a/tests/test_all_tasks_e2e.py
+++ b/tests/test_all_tasks_e2e.py
@@ -348,6 +348,62 @@ class TestAllTasks(unittest.TestCase):
         else:
             print("\n✅ All evaluation tests passed!")
 
+    def test_play_script(self):
+        """Smoke test for scripts/play.py using a single environment."""
+        play_script = os.path.join(self.project_root, "scripts", "play.py")
+        if not os.path.exists(play_script):
+            self.skipTest(f"Play script not found at {play_script}")
+
+        task = "Velocity-G1-History-v0"
+        num_envs = 2
+
+        cmd = [
+            self.isaaclab_script,
+            "-p",
+            play_script,
+            "--task",
+            task,
+            "--num_envs",
+            str(num_envs),
+            "--video",
+            "--video_length",
+            "10",
+            "--headless",
+        ]
+
+        env = dict(os.environ)
+        env["WANDB_MODE"] = "disabled"
+        env["OMNI_HEADLESS"] = "1"
+        env["DISPLAY"] = ":1"
+
+        print(f"\n{'=' * 60}", flush=True)
+        print(f"Testing play script: {task}", flush=True)
+        print("=" * 60, flush=True)
+        print(f"Command: {' '.join(cmd)}", flush=True)
+
+        try:
+            subprocess.run(
+                cmd,
+                check=True,
+                timeout=120,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            print(f"✅ Play script for {task} passed", flush=True)
+        except subprocess.CalledProcessError as e:
+            print(f"❌ Play script failed for {task}", flush=True)
+            print("STDOUT:", flush=True)
+            print(e.stdout[-2000:] if e.stdout else "No stdout", flush=True)
+            print("STDERR:", flush=True)
+            print(e.stderr[-2000:] if e.stderr else "No stderr", flush=True)
+            self.fail(f"Play script failed for {task}")
+        except subprocess.TimeoutExpired as e:
+            print(f"❌ Play script timed out for {task}", flush=True)
+            print("Partial STDOUT:", flush=True)
+            print(e.stdout[-2000:] if e.stdout else "No output", flush=True)
+            self.fail(f"Play script timed out for {task}")
+
 
 if __name__ == "__main__":
     # Run the tests

--- a/tests/test_e2e_ci_locally.sh
+++ b/tests/test_e2e_ci_locally.sh
@@ -206,6 +206,8 @@ EOF
             echo 'Testing all task environments...'
             \${ISAACLAB_PATH}/isaaclab.sh -p tests/test_all_tasks_e2e.py
             \${ISAACLAB_PATH}/isaaclab.sh -p tests/test_deterministic_eval_e2e.py
+            echo 'Testing Sim2MuJoCo pipeline...'
+            \${ISAACLAB_PATH}/isaaclab.sh -p tests/test_sim2mujoco_e2e.py
         "
     fi
 fi

--- a/tests/test_sim2mujoco_e2e.py
+++ b/tests/test_sim2mujoco_e2e.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""End-to-end test for Sim2MuJoCo evaluation."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestSim2MuJoCo(unittest.TestCase):
+    """Test case for running Sim2MuJoCo evaluation on different robots."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up the test environment once for all tests."""
+        # Get the project root directory
+        cls.project_root = Path(__file__).parent.parent.absolute()
+
+        # Path to the sim2mujoco eval script
+        cls.eval_script = os.path.join(cls.project_root, "scripts", "sim2mujoco_eval.py")
+
+        # Path to policy directory
+        policy_dir = os.path.join(cls.project_root, "agile", "data", "policy")
+
+        # Local assets directory (for T1)
+        local_assets_dir = os.path.join(cls.project_root, "agile", "rl_env", "assets", "robot_menagerie")
+
+        # Setup temporary directory for Unitree assets
+        cls.temp_dir = tempfile.mkdtemp()
+        print(f"\nCreated temporary directory for Unitree assets: {cls.temp_dir}")
+
+        # Pull Unitree MuJoCo repo on the fly
+        cls.unitree_assets_dir = cls._pull_unitree_repo(cls.temp_dir)
+
+        # --- G1 Configuration ---
+        cls.g1_ckpt = os.path.join(policy_dir, "velocity_height_g1", "unitree_g1_velocity_height_teacher.pt")
+        cls.g1_cfg = os.path.join(policy_dir, "velocity_height_g1", "unitree_g1_velocity_height_teacher.yaml")
+
+        # Use G1 from the pulled Unitree repo if available, otherwise fall back to local
+        # Note: unitree_mujoco/unitree_robots/g1/g1_29dof.xml
+        if cls.unitree_assets_dir:
+            cls.g1_mjcf = os.path.join(cls.unitree_assets_dir, "unitree_robots", "g1", "g1_29dof.xml")
+            print(f"Using G1 MJCF from Unitree repo: {cls.g1_mjcf}")
+        else:
+            # Fallback to local if pull failed
+            cls.g1_mjcf = os.path.join(local_assets_dir, "unitree", "g1", "mujoco", "g1_29dof.xml")
+            print(f"Using G1 MJCF from local assets: {cls.g1_mjcf}")
+
+        # --- G1 Velocity History Configuration ---
+        cls.g1_hist_ckpt = os.path.join(policy_dir, "velocity_g1", "unitree_g1_velocity_history.pt")
+        cls.g1_hist_cfg = os.path.join(policy_dir, "velocity_g1", "unitree_g1_velocity_history.yaml")
+        cls.g1_hist_mjcf = cls.g1_mjcf
+
+        # Check if script exists
+        if not os.path.exists(cls.eval_script):
+            raise unittest.SkipTest(f"Sim2MuJoCo script not found at {cls.eval_script}")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up temporary directory."""
+        if hasattr(cls, "temp_dir") and os.path.exists(cls.temp_dir):
+            shutil.rmtree(cls.temp_dir)
+            print(f"\nCleaned up temporary directory: {cls.temp_dir}")
+
+    @staticmethod
+    def _pull_unitree_repo(target_dir):
+        """Clone the Unitree MuJoCo repo to the target directory."""
+        repo_url = "https://github.com/unitreerobotics/unitree_mujoco.git"
+        print(f"Cloning {repo_url} to {target_dir}...")
+
+        try:
+            subprocess.run(
+                ["git", "clone", "--depth", "1", repo_url, target_dir],
+                check=True,
+                capture_output=True,
+                timeout=120,  # 2 mins timeout for clone
+            )
+            return target_dir
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            print(f"Failed to clone Unitree repo: {e}")
+            return None
+
+    def test_g1_velocity_height(self):
+        """Test G1 velocity height teacher policy in Sim2MuJoCo."""
+        self._run_eval(self.g1_ckpt, self.g1_cfg, self.g1_mjcf, "G1 Velocity Height")
+
+    def test_g1_velocity_history(self):
+        """Test G1 velocity policy with history in Sim2MuJoCo."""
+        self._run_eval(self.g1_hist_ckpt, self.g1_hist_cfg, self.g1_hist_mjcf, "G1 Velocity History")
+
+    def _run_eval(self, ckpt, cfg, mjcf, name):
+        """Helper to run the evaluation script."""
+        # Skip if checkpoint doesn't exist
+        if not os.path.exists(ckpt):
+            print(f"\n⚠️ Skipping {name}: Checkpoint not found at {ckpt}")
+            # We don't fail here to allow running tests even without all checkpoints locally
+            return
+
+        if not os.path.exists(mjcf):
+            print(f"❌ MJCF file not found at {mjcf}")
+            # If we expected it from the Unitree repo and it's missing, that's a fail
+            self.fail(f"MJCF file not found at {mjcf}")
+
+        print(f"\n{'=' * 60}")
+        print(f"Testing Sim2MuJoCo: {name}")
+        print("=" * 60)
+
+        # Determine if we're in CI environment (use isaaclab.sh) or local (use python directly)
+        isaaclab_path = os.environ.get("ISAACLAB_PATH")
+        if isaaclab_path and os.path.exists(os.path.join(isaaclab_path, "isaaclab.sh")):
+            # CI environment - use isaaclab.sh wrapper
+            cmd = [
+                os.path.join(isaaclab_path, "isaaclab.sh"),
+                "-p",
+                self.eval_script,
+                "--checkpoint",
+                ckpt,
+                "--config",
+                cfg,
+                "--mjcf",
+                mjcf,
+                "--duration",
+                "5.0",  # Run for 5 seconds
+                "--no-viewer",  # Headless
+                "--device",
+                "cpu",  # Use CPU for consistent testing
+                "--verbose",
+            ]
+        else:
+            # Local environment - use python directly
+            cmd = [
+                "python",
+                self.eval_script,
+                "--checkpoint",
+                ckpt,
+                "--config",
+                cfg,
+                "--mjcf",
+                mjcf,
+                "--duration",
+                "5.0",  # Run for 5 seconds
+                "--no-viewer",  # Headless
+                "--device",
+                "cpu",  # Use CPU for consistent testing
+                "--verbose",
+            ]
+
+        print(f"Running command: {' '.join(cmd)}")
+
+        try:
+            # Run the command with timeout
+            result = subprocess.run(
+                cmd,
+                check=True,
+                timeout=60,  # 1 minute timeout should be plenty for 5s sim
+                capture_output=True,
+                text=True,
+                env=os.environ,  # Pass current environment
+            )
+
+            print(f"✅ {name} passed")
+
+            # Verify output contains success message or steps
+            if "Evaluation complete!" not in result.stdout:
+                print("⚠️ Warning: 'Evaluation complete!' not found in stdout")
+
+        except subprocess.CalledProcessError as e:
+            print(f"❌ {name} failed with return code {e.returncode}")
+            print("STDERR:")
+            print(e.stderr[-2000:] if e.stderr else "No stderr")
+            print("STDOUT:")
+            print(e.stdout[-2000:] if e.stdout else "No stdout")
+            self.fail(f"{name} failed execution")
+
+        except subprocess.TimeoutExpired as e:
+            print(f"❌ {name} timed out")
+            print("Partial STDOUT:")
+            print(e.stdout[-2000:] if e.stdout else "No output")
+            self.fail(f"{name} timed out")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# [Feat] Sim2MuJoCo Evaluation Module

### 🎯 Purpose
Adds a lightweight, standalone tool to evaluate Isaac Lab policies directly in MuJoCo. This enables **Sim-to-Sim verification**, allowing us to double-check policy physics and robustness before deploying to real hardware.

### ✨ Key Features
- **Seamless Transfer:** Replicates Isaac Lab's observation and action processing exactly, ensuring policies behave consistently in MuJoCo.
- **Interactive Control:** Includes a viewer with keyboard controls to command the robot's velocity and height in real-time.
- **Universal Support:** Loads standard PyTorch (`.pt`) and ONNX checkpoints. Only IO descriptor YAML file is needed for a new task.
- **Automated Testing:** Includes new E2E tests that pull robot assets and verify policy execution automatically.

### 🏃‍♂️ Usage
python scripts/sim2mujoco_eval.py \
    --checkpoint path/to/policy.pt \
    --config path/to/config.yaml \
    --mjcf path/to/robot.xml

**Demo video:**
https://github.com/user-attachments/assets/6260cb0d-8cb0-4970-808e-ae08dca98522


### Others
**Minor fix:**
Fix the action dim calculation in play.py which is current broken when setting the `num_envs > 1`. System test is added to guard the script.