### PR TITLE
[Fix] Fixing the gain being not effective in the debug GUI

### DIFF
--- a/agile/rl_env/mdp/actions/actions_cfg.py
+++ b/agile/rl_env/mdp/actions/actions_cfg.py
@@ -95,8 +95,8 @@ class JointPositionGUIActionCfg(mdp.JointActionCfg):
     If True, this flag results in overwriting the values of :attr:`offset` to the default joint positions
     from the articulation asset.
     """
-    max_stiffness: float = 200.0
-    """Maximum stiffness for the P-gain slider. Defaults to 200.0."""
+    max_stiffness: float = 500.0
+    """Maximum stiffness for the P-gain slider. Defaults to 500.0."""
     max_damping: float = 25.0
     """Maximum damping for the D-gain slider. Defaults to 25.0."""
 

--- a/agile/rl_env/mdp/actions/joint_pos_gui_action.py
+++ b/agile/rl_env/mdp/actions/joint_pos_gui_action.py
@@ -83,6 +83,29 @@ class JointPositionGUIAction(JointPositionAction):
         self._mirror_actions = cfg.mirror_actions
         self._robot_type = cfg.robot_type
 
+        # Pre-allocate buffers for apply_actions (avoid per-step allocations)
+        self._full_stiffness_buffer = torch.zeros(self.num_envs, num_all_joints, device=self.device)
+        self._full_damping_buffer = torch.zeros(self.num_envs, num_all_joints, device=self.device)
+
+        # Pre-compute joint_ids as a tensor for efficient indexing
+        if isinstance(self._joint_ids, slice):
+            self._joint_ids_tensor = torch.arange(
+                self._joint_ids.start or 0,
+                self._joint_ids.stop,
+                self._joint_ids.step or 1,
+                device=self.device,
+            )
+        else:
+            self._joint_ids_tensor = torch.tensor(self._joint_ids, device=self.device, dtype=torch.long)
+
+        # Pre-compute actuator joint IDs as tensors
+        self._actuator_joint_ids: dict[str, torch.Tensor] = {}
+        for name, actuator in self._asset.actuators.items():
+            actuator_joint_ids = self._asset.find_joints(actuator.joint_names)[0]
+            self._actuator_joint_ids[name] = torch.tensor(
+                actuator_joint_ids, device=self.device, dtype=torch.long
+            )
+
         if self._robot_type == "g1":
             self._symmetry_augmentation_func = lr_mirror_G1
         elif self._robot_type == "t1":
@@ -331,39 +354,22 @@ class JointPositionGUIAction(JointPositionAction):
 
         self._asset.set_joint_position_target(full_pos, joint_ids=self._joint_ids)
 
-        # Apply PD gains
-        if isinstance(self._joint_ids, slice):
-            # Create a tensor representing the range of the slice
-            joint_ids_tensor = torch.arange(
-                self._joint_ids.start or 0,
-                self._joint_ids.stop,
-                self._joint_ids.step or 1,
-                device=self.device,
-            )
-        else:
-            joint_ids_tensor = torch.tensor(self._joint_ids, device=self.device)
-
-        # Create a full tensor for all stiffness and damping values
-        full_stiffness = torch.cat(
-            [actuator.stiffness.clone() for actuator in self._asset.actuators.values()],
-            dim=1,
-        )
-        full_damping = torch.cat(
-            [actuator.damping.clone() for actuator in self._asset.actuators.values()],
-            dim=1,
-        )
+        # Apply PD gains using pre-allocated buffers
+        # Populate from actuators in correct joint positions
+        for name, actuator in self._asset.actuators.items():
+            joint_ids = self._actuator_joint_ids[name]
+            self._full_stiffness_buffer[:, joint_ids] = actuator.stiffness
+            self._full_damping_buffer[:, joint_ids] = actuator.damping
 
         # Update the values for the selected joints
-        full_stiffness[:, joint_ids_tensor] = target_stiffness
-        full_damping[:, joint_ids_tensor] = target_damping
+        self._full_stiffness_buffer[:, self._joint_ids_tensor] = target_stiffness
+        self._full_damping_buffer[:, self._joint_ids_tensor] = target_damping
 
         # Distribute the updated values back to the actuators
-        offset = 0
-        for actuator in self._asset.actuators.values():
-            num_dof = actuator.stiffness.shape[1]
-            actuator.stiffness[:] = full_stiffness.narrow(1, offset, num_dof)
-            actuator.damping[:] = full_damping.narrow(1, offset, num_dof)
-            offset += num_dof
+        for name, actuator in self._asset.actuators.items():
+            joint_ids = self._actuator_joint_ids[name]
+            actuator.stiffness[:] = self._full_stiffness_buffer.index_select(1, joint_ids)
+            actuator.damping[:] = self._full_damping_buffer.index_select(1, joint_ids)
 
     # ---------------------------------------------------------------------
     # Misc helpers


### PR DESCRIPTION
Fix PD gain control in JointPositionGUIAction

**Problem**
Changing PD gains via the GUI sliders had no effect on actual joint tracking. Setting gains to 0 still resulted in joints moving to target positions.

**Root Cause**
In apply_actions(), the gain tensors were built by concatenating actuators in iteration order, but indexed using global joint IDs—a mismatch that caused incorrect gain mapping.

**Fix**
Build full gain tensors indexed by global joint ID (matching `__init__` structure)
Use `find_joints()` to correctly map between actuator joints and global joint indices
Pre-allocate buffers (`_full_stiffness_buffer`, `_full_damping_buffer`) and pre-compute joint ID tensors in `__init__` to avoid per-step allocations