### PR TITLE
fix: correct MISSING import and support MOTION_FILE env var in tracki…

### DIFF
--- a/agile/rl_env/tasks/tracking/g1/flat_env_cfg.py
+++ b/agile/rl_env/tasks/tracking/g1/flat_env_cfg.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import MISSING
+import os
+from dataclasses import MISSING
 
 from isaaclab.utils import configclass
 
@@ -30,7 +31,7 @@ class G1FlatEnvCfg(TrackingEnvCfg):
         self.actions.joint_pos.scale = G1_29DOF_ACTION_SCALE
         self.commands.motion.anchor_body_name = "torso_link"
         self.commands.motion.debug_vis = False
-        self.commands.motion.motion_file = MISSING
+        self.commands.motion.motion_file = os.environ.get("MOTION_FILE", MISSING)
         self.commands.motion.body_names = [
             "pelvis",
             "left_hip_roll_link",


### PR DESCRIPTION
  Summary

  Fix ImportError in Tracking-Flat-G1-v0 task config and add MOTION_FILE environment variable support for specifying motion data path.

  Motivation

  The tracking task (Tracking-Flat-G1-v0) cannot be launched on Isaac Lab 2.3.1 (Python 3.11) due to two issues:

  1. from typing import MISSING causes ImportError — Python's typing module has never exported MISSING. The sentinel value comes from the dataclasses module. This makes the
   G1 whole-body motion tracking task completely unusable:
  File "agile/rl_env/tasks/tracking/g1/flat_env_cfg.py", line 16, in <module>
      from typing import MISSING
  ImportError: cannot import name 'MISSING' from 'typing'
  2. No way to pass motion_file at launch time — Even after fixing the import, motion_file is set to MISSING (a required field with no default). The intended approach of
  overriding it via Hydra CLI (commands.motion.motion_file=/path/to/file.npz) fails because Isaac Lab's Hydra integration does not expose nested commands.* keys in its
  config struct:
  Could not override 'commands.motion.motion_file'.
  Key 'commands' is not in struct
  2. This leaves users with no straightforward way to provide the motion .npz file without editing source code.

  Changes

  - Fix import: from typing import MISSING → from dataclasses import MISSING
  - Read MOTION_FILE environment variable at config init time, falling back to MISSING when unset. This allows users to specify the motion data path without modifying code:
  export MOTION_FILE=/path/to/converted_motion.npz
  python scripts/train.py --task Tracking-Flat-G1-v0 ...

  Testing

  - Verified Tracking-Flat-G1-v0 launches successfully with 8-GPU distributed training (torchrun, NCCL gradient sync) on Isaac Lab 2.3.1 Docker image
  (nvcr.io/nvidia/isaac-lab:2.3.1, Python 3.11)
  - Motion data: AMASS Retargeted for G1 (Salsa Shines, 127.5s / 6375 frames @ 50fps), converted via scripts/utils/convert_retargeted_data_for_tracking.py
  - Training runs to iteration 50000 with 4096 envs per GPU (32768 total), all 13 reward terms active, no errors
  - Without MOTION_FILE env var set, behavior is identical to before the fix (config requires user to provide the path)


-
