### PR TITLE
fix(sim2mujoco): truncate generated_commands for velocity-only policies

### DIFF
--- a/agile/sim2mujoco/observations.py
+++ b/agile/sim2mujoco/observations.py
@@ -514,8 +514,8 @@ class ObservationProcessor:
         For motion tracking policies: returns cat([target_joint_pos, target_joint_vel])
         from the motion data (in the policy's joint ordering).
 
-        For velocity/height policies: returns [vx, vy, wz, height] padded to
-        the expected dimension.
+        For velocity/height policies: returns the CommandManager's
+        [vx, vy, wz, height] resized (padded or truncated) to the expected dim.
         """
         if self.motion_tracker is not None:
             return self.motion_tracker.get_command()
@@ -526,10 +526,14 @@ class ObservationProcessor:
         else:
             cmd = torch.tensor([0.0, 0.0, 0.0, 0.72], device=self.device, dtype=torch.float32)
 
-        # Pad to expected dimension if needed.
+        # Resize to expected dimension: pad with zeros if short, drop trailing
+        # entries if long. Velocity-only policies (obs_dim == 3) expect
+        # [vx, vy, wz] and must not receive the trailing height entry.
         if cmd.shape[0] < term.obs_dim:
             padding = torch.zeros(term.obs_dim - cmd.shape[0], device=self.device, dtype=torch.float32)
             cmd = torch.cat([cmd, padding], dim=0)
+        elif cmd.shape[0] > term.obs_dim:
+            cmd = cmd[: term.obs_dim]
 
         return cmd
 


### PR DESCRIPTION
## Summary

- `CommandManager.get_command()` always returns 4 values `[vx, vy, wz, height]`, but velocity-only policies declare `generated_commands` with `shape: [3]` in the IO-descriptor YAML.
- `_compute_generated_commands` only padded short command tensors; when the manager's output was longer than `term.obs_dim` the 4-wide tensor collided with the 3-wide history buffer on step 1:
  ```
  RuntimeError: The expanded size of the tensor (3) must match the existing size (4) at non-singleton dimension 0.
  ```
- Added the symmetric trim branch so the output matches `term.obs_dim` in both directions.

We could also modify this command to check the length of the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)