### PR TITLE
[feat] Add HeightTracking-G1-v0 task (stand-up / lie-down)

### DIFF
--- a/agile/algorithms/rsl_rl/rsl_rl/algorithms/ppo.py
+++ b/agile/algorithms/rsl_rl/rsl_rl/algorithms/ppo.py
@@ -503,12 +503,24 @@ class PPO:
             if self.use_l2c2 and l2c2_batch is not None:
                 prev_obs_batch, next_obs_batch, prev_priv_obs_batch, next_priv_obs_batch, done_mask_batch = l2c2_batch
 
-                interpolation_factor = torch.rand(prev_obs_batch.shape[0], 1, device=self.device)
+                batch_size = prev_obs_batch.shape[0]
+                # Shape interpolation factor to match obs layout:
+                # - Regular tensor [batch, obs_dim]: use [batch, 1] to broadcast over features
+                # - TensorDict or 1D tensor [batch]: use [batch] (features are inside TD leaves)
+                if prev_obs_batch.dim() >= 2:
+                    interpolation_factor = torch.rand(batch_size, 1, device=self.device)
+                else:
+                    interpolation_factor = torch.rand(batch_size, device=self.device)
                 interpolated_obs = prev_obs_batch + interpolation_factor * (next_obs_batch - prev_obs_batch)
-                interpolated_priv_obs = prev_priv_obs_batch + interpolation_factor * (next_priv_obs_batch - prev_priv_obs_batch)
-                
-                distance =torch.nn.MSELoss()
-                l2c2_actor_loss = distance(self.policy.act_inference(interpolated_obs[~done_mask_batch]), self.policy.act_inference(prev_obs_batch[~done_mask_batch])) 
+
+                if prev_priv_obs_batch.dim() >= 2:
+                    priv_interpolation_factor = torch.rand(batch_size, 1, device=self.device)
+                else:
+                    priv_interpolation_factor = torch.rand(batch_size, device=self.device)
+                interpolated_priv_obs = prev_priv_obs_batch + priv_interpolation_factor * (next_priv_obs_batch - prev_priv_obs_batch)
+
+                distance = torch.nn.MSELoss()
+                l2c2_actor_loss = distance(self.policy.act_inference(interpolated_obs[~done_mask_batch]), self.policy.act_inference(prev_obs_batch[~done_mask_batch]))
                 l2c2_critic_loss = distance(self.policy.evaluate(interpolated_priv_obs[~done_mask_batch]), self.policy.evaluate(prev_priv_obs_batch[~done_mask_batch]))
                 loss += self.lambda_actor * l2c2_actor_loss
                 loss += self.lambda_critic * l2c2_critic_loss

--- a/agile/rl_env/assets/robots/unitree_g1.py
+++ b/agile/rl_env/assets/robots/unitree_g1.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+import copy as _copy
+
 import isaaclab.sim as sim_utils
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.assets import ArticulationCfg
@@ -862,3 +864,51 @@ for _a in G1_W_HANDS_AGILE_CFG.actuators.values():
     for _n in _names:
         if _n in _e and _n in _s and _s[_n]:
             G1_W_HANDS_AGILE_ACTION_SCALE[_n] = 0.25 * _e[_n] / _s[_n]
+
+G1_NO_HANDS_AGILE_ACTION_SCALE = {k: v for k, v in G1_W_HANDS_AGILE_ACTION_SCALE.items() if "hand" not in k}
+
+
+# ---------------------------------------------------------------------------
+# G1 29-DOF config tuned for HeightTracking (stand-up / lie-down).
+# Derived from G1_29DOF_DELAYED_DC_MOTOR with lower stiffness/damping,
+# uniform saturation effort, and added joint friction.
+# ---------------------------------------------------------------------------
+
+G1_29DOF_HEIGHT_TRACKING = _copy.deepcopy(G1_29DOF_DELAYED_DC_MOTOR)
+
+_ht_actuators = G1_29DOF_HEIGHT_TRACKING.actuators
+# Legs: softer knees
+_ht_actuators["legs"].stiffness[".*_knee_joint"] = 100.0
+_ht_actuators["legs"].damping[".*_knee_joint"] = 2.5
+_ht_actuators["legs"].armature = 0.02
+_ht_actuators["legs"].friction = 0.01
+_ht_actuators["legs"].saturation_effort = 130.0
+# Feet: higher damping for stability
+_ht_actuators["feet"].damping[".*_ankle_pitch_joint"] = 1.0
+_ht_actuators["feet"].damping[".*_ankle_roll_joint"] = 1.0
+_ht_actuators["feet"].friction = 0.01
+_ht_actuators["feet"].saturation_effort = 130.0
+# Waist: much softer for compliant torso
+_ht_actuators["waist"].stiffness = {"waist_yaw_joint": 100.0, "waist_roll_joint": 100.0, "waist_pitch_joint": 100.0}
+_ht_actuators["waist"].damping = {"waist_yaw_joint": 2.5, "waist_roll_joint": 2.5, "waist_pitch_joint": 2.5}
+_ht_actuators["waist"].friction = 0.01
+_ht_actuators["waist"].saturation_effort = 130.0
+# Arms: uniform low stiffness/damping for relaxed arms
+_ht_actuators["arms"].stiffness = {
+    ".*_shoulder_pitch_joint": 20.0,
+    ".*_shoulder_roll_joint": 20.0,
+    ".*_shoulder_yaw_joint": 20.0,
+    ".*_elbow_joint": 20.0,
+    ".*_wrist_.*_joint": 20.0,
+}
+_ht_actuators["arms"].damping = {
+    ".*_shoulder_pitch_joint": 0.5,
+    ".*_shoulder_roll_joint": 0.5,
+    ".*_shoulder_yaw_joint": 0.5,
+    ".*_elbow_joint": 0.5,
+    ".*_wrist_.*_joint": 0.2,
+}
+_ht_actuators["arms"].armature = 0.02
+_ht_actuators["arms"].friction = 0.01
+_ht_actuators["arms"].saturation_effort = 130.0
+del _ht_actuators

--- a/agile/rl_env/mdp/actions/actions_cfg.py
+++ b/agile/rl_env/mdp/actions/actions_cfg.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 from dataclasses import MISSING, field
 from typing import Literal
 
@@ -147,7 +148,7 @@ class LiftActionCfg(ActionTermCfg):
     """Action term to simulate a lift.
 
     Applies external forces to lift the robot up and torques to damp angular velocity.
-    Use with a curriculum term (e.g., `remove_harness` or `adaptive_lift_curriculum`)
+    Use with a curriculum term (e.g., `remove_harness` or `adaptive_force_decay`)
     to reduce forces over training.
     """
 
@@ -160,7 +161,10 @@ class LiftActionCfg(ActionTermCfg):
     damping_forces: float = 0.0
     """The damping (D gain) for height tracking. Defaults to 0.0."""
     force_limit: float = 0.0
-    """The maximum force to apply. Defaults to 0.0."""
+    """The maximum force to apply. Defaults to 0.0. Overridden by force_limit_weight_fraction if set."""
+    force_limit_weight_fraction: float | None = None
+    """If set, overrides force_limit with this fraction of the robot's total weight (mass * gravity).
+    E.g., 0.9 means the lift can apply up to 90% of the robot's weight. Defaults to None."""
     damping_torques: float = 0.0
     """The damping for angular velocity (D term). Applies torques opposing yaw rotation. Defaults to 0.0."""
     torque_limit: float = 0.0
@@ -171,10 +175,18 @@ class LiftActionCfg(ActionTermCfg):
     """The target standing height. Defaults to 0.71."""
     height_command: str | None = None
     """Optional command term name for dynamic height targets."""
+    allow_push_down: bool = False
+    """If True, forces can be negative (push down). If False (default), only upward forces are applied."""
     start_lifting_time_s: float = 0.0
     """Delay before lifting starts (seconds). Defaults to 0.0."""
     lifting_duration_s: float = 10.0
-    """How many seconds the lift should take to move from start to end"""
+    """Time to ramp from 0 to target height (seconds). Defaults to 10.0."""
+    force_offset: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    """Offset in body frame (x, y, z) from body origin where force is applied.
+
+    Positive z shifts the application point upward along the body's local z-axis.
+    This is useful to apply the lift force at a higher point than the body origin,
+    e.g., at the chest instead of the pelvis. Defaults to (0.0, 0.0, 0.0)."""
 
 
 @configclass

--- a/agile/rl_env/mdp/actions/lift_action.py
+++ b/agile/rl_env/mdp/actions/lift_action.py
@@ -39,7 +39,7 @@ class LiftAction(ActionTerm):
     that increases linearly over time. Also applies angular velocity damping to prevent
     spinning.
 
-    Use a curriculum (e.g., `remove_harness` or `adaptive_lift_curriculum`) to reduce
+    Use a curriculum (e.g., `remove_harness` or `adaptive_force_decay`) to reduce
     the forces over time as the robot learns to stand up on its own.
     """
 
@@ -60,8 +60,25 @@ class LiftAction(ActionTerm):
         self._torque_limit = cfg.torque_limit
         # height sensor
         self._height_sensor: RayCaster = env.scene.sensors[cfg.height_sensor]
+
+        # Override force limit based on robot weight if configured
+        if cfg.force_limit_weight_fraction is not None:
+            total_mass = self._asset.data.default_mass.sum(dim=1).mean().item()
+            gravity = abs(env.cfg.sim.gravity[2]) if hasattr(env.cfg.sim, "gravity") else 9.81
+            self._force_limit = cfg.force_limit_weight_fraction * total_mass * gravity
+        # Store base force limit for curriculum scaling
+        self._base_force_limit = self._force_limit
         self._lift_link_id, _ = self._asset.find_bodies(cfg.link_to_lift)
         self._is_disabled = False
+
+        # Force application offset in body frame
+        self._force_offset = torch.tensor(cfg.force_offset, device=env.device, dtype=torch.float32)
+
+        # Resolve height command if configured (otherwise use time-based ramp)
+        if cfg.height_command is not None:
+            self._height_command = env.command_manager.get_term(cfg.height_command)
+        else:
+            self._height_command = None
 
         # Force scale for curriculum (1.0 = full force, 0.0 = disabled)
         self._force_scale = 1.0
@@ -90,7 +107,7 @@ class LiftAction(ActionTerm):
     def max_heights(self) -> torch.Tensor:
         """Max height achieved per environment during current episode.
 
-        Used by adaptive_lift_curriculum to determine if robot successfully
+        Used by adaptive_force_decay (metric_type="standing_ratio") to determine if robot successfully
         stood up at any point (even if it fell afterwards).
         """
         return self._max_heights
@@ -106,7 +123,7 @@ class LiftAction(ActionTerm):
         self._force_scale = scale
         self.stiffness_forces = self.cfg.stiffness_forces * self._force_scale
         self.damping_forces = self.cfg.damping_forces * self._force_scale
-        self._force_limit = self.cfg.force_limit * self._force_scale
+        self._force_limit = self._base_force_limit * self._force_scale
         self.damping_torques = self.cfg.damping_torques * self._force_scale
         self._torque_limit = self.cfg.torque_limit * self._force_scale
         self._is_disabled = self._force_scale <= 0
@@ -115,10 +132,21 @@ class LiftAction(ActionTerm):
         # store the raw actions
         self._raw_actions = actions
 
+    def _measure_height(self) -> torch.Tensor:
+        """Measure the current height for PD control.
+
+        When a height command with an offset is used, measures the offset point height
+        (matching what the command tracks). Otherwise measures root height.
+        """
+        if self._height_command is not None:
+            return self._height_command.measured_height
+        else:
+            height = self._asset.data.root_pos_w[:, 2].unsqueeze(1) - self._height_sensor.data.ray_hits_w[..., 2]
+            return torch.mean(height, dim=-1)
+
     def apply_actions(self) -> None:
         # Always compute and track height (even when disabled) for curriculum
-        height = self._asset.data.root_pos_w[:, 2].unsqueeze(1) - self._height_sensor.data.ray_hits_w[..., 2]
-        height = torch.mean(height, dim=-1)
+        height = self._measure_height()
 
         # Track max height achieved during episode
         self._max_heights = torch.maximum(self._max_heights, height)
@@ -127,20 +155,32 @@ class LiftAction(ActionTerm):
             return
 
         # find current desired height above ground
-        time_passed = self._env.episode_length_buf * self._env.step_dt
-        ratio = torch.clamp(
-            (time_passed - self.cfg.start_lifting_time_s) / self.cfg.lifting_duration_s, min=0.0, max=1.0
-        )
-        target_height = ratio * self.cfg.target_height
+        if self._height_command is not None:
+            target_height = self._height_command.target_height
+        else:
+            # Default: time-based linear ramp
+            time_passed = self._env.episode_length_buf * self._env.step_dt
+            ratio = torch.clamp(
+                (time_passed - self.cfg.start_lifting_time_s) / self.cfg.lifting_duration_s, min=0.0, max=1.0
+            )
+            target_height = ratio * self.cfg.target_height
 
         # find the error in local frame of root
         forces = torch.zeros_like(self._asset.data.root_lin_vel_b)
         # calculate the height error
-        height_error = target_height - height  # (N, 1)
+        height_error = target_height - height  # (N,)
         # apply the height error to the forces
         forces[:, 2] = self.stiffness_forces * height_error
+        # Disable the lift assist for negative commanded heights: "lie flat" is a
+        # joint-configuration task (the policy splays the legs), not a force-support
+        # task, and the assist should neither pull the robot up nor push it into the ground.
+        if self._height_command is not None:
+            forces[:, 2] = torch.where(target_height >= 0, forces[:, 2], torch.zeros_like(forces[:, 2]))
         # limit the forces
-        forces = torch.clamp(forces, 0.0, self._force_limit).unsqueeze(1)
+        if self.cfg.allow_push_down:
+            forces = torch.clamp(forces, -self._force_limit, self._force_limit).unsqueeze(1)
+        else:
+            forces = torch.clamp(forces, 0.0, self._force_limit).unsqueeze(1)
 
         # Angular velocity damping (D term) - only on z-axis (yaw) in world frame
         # This prevents fast spinning while allowing roll/pitch for balance
@@ -152,7 +192,9 @@ class LiftAction(ActionTerm):
             # Clamp torques
             torques_w[:, 2] = torch.clamp(torques_w[:, 2], -self._torque_limit, self._torque_limit)
 
-        # Apply forces and torques in world frame
+        # Isaac Lab 2.3.1 does not expose permanent_wrench_composer, so we fall back to
+        # set_external_force_and_torque which applies the wrench at the body origin.
+        # The force_offset field is not respected in this code path.
         self._asset.set_external_force_and_torque(
             forces=forces, torques=torques_w.unsqueeze(1), body_ids=self._lift_link_id, is_global=True
         )

--- a/agile/rl_env/mdp/commands/__init__.py
+++ b/agile/rl_env/mdp/commands/__init__.py
@@ -26,6 +26,8 @@ from .commands_cfg import (
     UniformVelocityBaseHeightCommandCfg,
     UniformVelocityGaitBaseHeightCommandCfg,
 )
+from .height_command import SmoothHeightCommand
+from .height_command_cfg import SmoothHeightCommandCfg
 from .motion_tracking_commands import MotionCommand
 from .motion_tracking_commands_cfg import MotionCommandCfg
 from .tracking_commands import TrackingCommand
@@ -38,6 +40,8 @@ __all__ = [
     "UniformVelocityBaseHeightCommandCfg",
     "UniformVelocityGaitBaseHeightCommand",
     "UniformVelocityGaitBaseHeightCommandCfg",
+    "SmoothHeightCommand",
+    "SmoothHeightCommandCfg",
     "TrackingCommand",
     "TrackingCommandCfg",
     "MotionCommand",

--- a/agile/rl_env/mdp/commands/height_command.py
+++ b/agile/rl_env/mdp/commands/height_command.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import torch
+
+from isaaclab.assets import Articulation
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.managers import CommandTerm
+from isaaclab.markers import VisualizationMarkers
+from isaaclab.sensors import RayCaster
+from isaaclab.utils.math import quat_apply
+
+if TYPE_CHECKING:
+    from .height_command_cfg import SmoothHeightCommandCfg
+
+
+class SmoothHeightCommand(CommandTerm):
+    """Command term that generates smooth height targets for stand-up tasks.
+
+    Samples random target heights and ramp velocities at each resample interval.
+    Between resamples, the command smoothly ramps toward the target at the sampled
+    velocity (linear interpolation, never instant).
+
+    On reset, initializes to the robot's current body height above ground.
+    """
+
+    cfg: SmoothHeightCommandCfg
+
+    def __init__(self, cfg: SmoothHeightCommandCfg, env: ManagerBasedRLEnv) -> None:
+        super().__init__(cfg, env)
+
+        self.robot: Articulation = env.scene[cfg.asset_name]
+        self._height_sensor: RayCaster = env.scene.sensors[cfg.height_sensor]
+
+        # Resolve body index
+        body_ids, _ = self.robot.find_bodies(cfg.body_name)
+        if len(body_ids) == 0:
+            raise ValueError(f"Body '{cfg.body_name}' not found in robot.")
+        self._body_id = body_ids[0]
+
+        # Local frame offset for the tracked point.
+        # This allows tracking a point that is not at the body frame origin — e.g.
+        # the CoM or a sensor location.  The offset is expressed in the body's local
+        # frame and gets rotated into world frame each step via quat_apply.
+        self._offset_local = torch.tensor(cfg.offset.pos, device=self.device, dtype=torch.float32)
+
+        # Buffers
+        self._target_height = torch.zeros(self.num_envs, device=self.device)
+        self._current_height_cmd = torch.zeros(self.num_envs, device=self.device)
+        self._velocity = torch.zeros(self.num_envs, device=self.device)
+
+        # Metrics — episode mean height error (with resample grace period)
+        self.metrics["height_error"] = torch.zeros(self.num_envs, device=self.device)
+
+        # Episode error accumulation buffers
+        self._episode_error_sum = torch.zeros(self.num_envs, device=self.device)
+        self._episode_step_count = torch.zeros(self.num_envs, device=self.device)
+
+        # Steps since last resample (for settle / grace period)
+        self._steps_since_resample = torch.zeros(self.num_envs, device=self.device)
+        self._settle_steps = int(cfg.settle_time_s / env.step_dt)
+
+    @property
+    def command(self) -> torch.Tensor:
+        """The current smooth height command. Shape: [num_envs, 1]."""
+        return self._current_height_cmd.unsqueeze(-1)
+
+    @property
+    def target_height(self) -> torch.Tensor:
+        """The current smooth height target (for lift action / rewards). Shape: [num_envs]."""
+        return self._current_height_cmd
+
+    @property
+    def measured_height(self) -> torch.Tensor:
+        """The actual body height above ground. Shape: [num_envs]."""
+        return self._measure_height()
+
+    @property
+    def settled(self) -> torch.Tensor:
+        """Bool tensor [num_envs] — True when enough time has passed since last resample."""
+        return self._steps_since_resample > self._settle_steps
+
+    @property
+    def relaxation_intensity(self) -> torch.Tensor:
+        """Float tensor [num_envs] in [0, 1]. 0 when command >= 0, 1 at the most negative command."""
+        min_height = self.cfg.ranges.height[0]
+        if min_height >= 0:
+            return torch.zeros(self.num_envs, device=self.device)
+        return torch.clamp(-self._current_height_cmd / (-min_height), 0.0, 1.0)
+
+    def _tracked_point_pos_w(self) -> torch.Tensor:
+        """Compute the world position of the tracked point (body origin + rotated offset). Shape: [num_envs, 3]."""
+        body_pos_w = self.robot.data.body_pos_w[:, self._body_id, :]  # (num_envs, 3)
+        body_quat_w = self.robot.data.body_quat_w[:, self._body_id, :]  # (num_envs, 4)
+        offset_w = quat_apply(body_quat_w, self._offset_local.expand(self.num_envs, -1))
+        return body_pos_w + offset_w
+
+    def _measure_height(self) -> torch.Tensor:
+        """Measure the tracked point's height above ground using the height sensor."""
+        point_z_w = self._tracked_point_pos_w()[:, 2]
+        ground_height = torch.mean(self._height_sensor.data.ray_hits_w[..., 2], dim=-1)
+        return point_z_w - ground_height
+
+    def _resample_command(self, env_ids: Sequence[int]) -> None:
+        """Sample new target height and ramp velocity."""
+        self._steps_since_resample[env_ids] = 0
+
+        n = len(env_ids)
+        r = self.cfg.ranges
+
+        # Sample target heights with biased distribution
+        roll = torch.rand(n, device=self.device)
+        standing_mask = roll < self.cfg.standing_ratio
+        flat_mask = (~standing_mask) & (roll < self.cfg.standing_ratio + self.cfg.flat_ratio)
+        uniform_mask = ~standing_mask & ~flat_mask
+
+        heights = torch.empty(n, device=self.device)
+        heights[standing_mask] = r.height[1]
+        heights[flat_mask] = r.height[0]
+        heights[uniform_mask] = torch.empty(uniform_mask.sum().item(), device=self.device).uniform_(
+            r.height[0], r.height[1]
+        )
+        self._target_height[env_ids] = heights
+
+        # Sample ramp velocities
+        v_min, v_max = self.cfg.velocity_range
+        self._velocity[env_ids] = torch.empty(n, device=self.device).uniform_(v_min, v_max)
+
+    def _update_command(self) -> None:
+        """Ramp current command toward target at sampled velocity."""
+        dt = self._env.step_dt
+        diff = self._target_height - self._current_height_cmd
+        max_step = self._velocity * dt
+
+        # Move toward target, clamping step size to avoid overshoot
+        step = torch.clamp(diff, -max_step, max_step)
+        self._current_height_cmd += step
+
+    def _update_metrics(self) -> None:
+        """Track episode-mean height error, skipping settle period and negative commands."""
+        error = torch.abs(self.measured_height - self._current_height_cmd)
+
+        # Accumulate only when settled AND command is non-negative
+        self._steps_since_resample += 1
+        valid = (self._steps_since_resample > self._settle_steps) & (self._current_height_cmd >= 0)
+        self._episode_error_sum += error * valid
+        self._episode_step_count += valid.float()
+        self.metrics["height_error"] = self._episode_error_sum / self._episode_step_count.clamp(min=1)
+
+    def reset(self, env_ids: Sequence[int] | None = None) -> dict[str, float]:
+        """Reset command to current body height for given envs."""
+        if env_ids is None:
+            env_ids = torch.arange(self.num_envs, device=self.device)
+
+        # Reset episode error accumulators
+        self._episode_error_sum[env_ids] = 0.0
+        self._episode_step_count[env_ids] = 0.0
+
+        # Initialize command to current measured height, clamped to configured range
+        r = self.cfg.ranges
+        self._current_height_cmd[env_ids] = self._measure_height()[env_ids].clamp(r.height[0], r.height[1])
+
+        # Let parent handle resampling (calls _resample_command)
+        result: dict[str, float] = super().reset(env_ids)
+        return result
+
+    def _set_debug_vis_impl(self, debug_vis: bool) -> None:
+        if debug_vis:
+            if not hasattr(self, "_goal_marker"):
+                self._goal_marker = VisualizationMarkers(self.cfg.goal_visualizer_cfg)
+                self._measured_marker = VisualizationMarkers(self.cfg.measured_visualizer_cfg)
+            self._goal_marker.set_visibility(True)
+            self._measured_marker.set_visibility(True)
+        else:
+            if hasattr(self, "_goal_marker"):
+                self._goal_marker.set_visibility(False)
+                self._measured_marker.set_visibility(False)
+
+    def _debug_vis_callback(self, event: object) -> None:  # noqa ARG002
+        if not self.robot.is_initialized:
+            return
+        tracked_pos = self._tracked_point_pos_w()
+        ground_height = torch.mean(self._height_sensor.data.ray_hits_w[..., 2], dim=-1)
+
+        # goal marker: commanded height, shifted in world X so it's visible
+        goal_pos = tracked_pos.clone()
+        goal_pos[:, 0] += 0.25
+        goal_pos[:, 2] = ground_height + self._current_height_cmd
+        self._goal_marker.visualize(goal_pos)
+
+        # measured marker: actual tracked point height, same world X shift
+        measured_pos = tracked_pos.clone()
+        measured_pos[:, 0] += 0.25
+        self._measured_marker.visualize(measured_pos)

--- a/agile/rl_env/mdp/commands/height_command_cfg.py
+++ b/agile/rl_env/mdp/commands/height_command_cfg.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import isaaclab.sim as sim_utils
+from isaaclab.managers import CommandTermCfg
+from isaaclab.markers import VisualizationMarkersCfg
+from isaaclab.utils import configclass
+
+from .height_command import SmoothHeightCommand
+
+
+@configclass
+class SmoothHeightCommandCfg(CommandTermCfg):
+    """Configuration for the smooth height command term.
+
+    Commands a target height that ramps smoothly between randomly sampled
+    targets at random velocities. Never changes instantly.
+    """
+
+    class_type: type = SmoothHeightCommand
+
+    asset_name: str = "robot"
+    """Name of the robot asset in the scene."""
+
+    @configclass
+    class Ranges:
+        """Ranges for height sampling."""
+
+        height: tuple[float, float] = (0.0, 0.75)
+        """Range of target heights to sample (meters)."""
+
+    ranges: Ranges = Ranges()
+    """Ranges for command sampling."""
+
+    @configclass
+    class OffsetCfg:
+        """The offset of the tracked point from the body frame origin."""
+
+        pos: tuple[float, float, float] = (0.0, 0.0, 0.0)
+        """Translation w.r.t. the body's local frame. Defaults to (0.0, 0.0, 0.0)."""
+
+    body_name: str = "torso_link"
+    """Body whose height is tracked and commanded."""
+
+    offset: OffsetCfg = OffsetCfg()
+    """Offset of the tracked point from the body frame origin. Defaults to zero offset."""
+
+    height_sensor: str = "height_measurement_sensor"
+    """Name of the raycaster sensor for terrain-relative height measurement."""
+
+    velocity_range: tuple[float, float] = (0.05, 0.5)
+    """Range of ramp velocities (m/s). Min > 0 ensures no instant transitions.
+    Use very large values (e.g. 1000.0) for instant jumps."""
+
+    settle_time_s: float = 1.0
+    """Seconds after each resample before tracking is expected.
+
+    During the settle period, the ``settled`` property returns False and
+    the height-error metric ignores these steps.  Also used as the grace
+    period for the episode-mean height-error metric.
+    """
+
+    standing_ratio: float = 0.0
+    """Fraction of resamples that set the target to the maximum height (standing). Defaults to 0.0."""
+
+    flat_ratio: float = 0.0
+    """Fraction of resamples that set the target to the minimum height (lying down). Defaults to 0.0."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.standing_ratio + self.flat_ratio > 1.0:
+            raise ValueError(
+                f"standing_ratio ({self.standing_ratio}) + flat_ratio ({self.flat_ratio}) must not exceed 1.0"
+            )
+
+    goal_visualizer_cfg: VisualizationMarkersCfg = VisualizationMarkersCfg(
+        prim_path="/Visuals/Command/height_goal",
+        markers={
+            "cube": sim_utils.CuboidCfg(
+                size=(0.05, 0.05, 0.05),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 1.0, 0.0), opacity=0.7),
+            ),
+        },
+    )
+    """Configuration for the goal height visualization marker (green)."""
+
+    measured_visualizer_cfg: VisualizationMarkersCfg = VisualizationMarkersCfg(
+        prim_path="/Visuals/Command/height_measured",
+        markers={
+            "cube": sim_utils.CuboidCfg(
+                size=(0.05, 0.05, 0.05),
+                visual_material=sim_utils.PreviewSurfaceCfg(diffuse_color=(0.0, 0.5, 1.0), opacity=0.7),
+            ),
+        },
+    )
+    """Configuration for the measured height visualization marker (blue)."""

--- a/agile/rl_env/mdp/curriculums/task_curriculum.py
+++ b/agile/rl_env/mdp/curriculums/task_curriculum.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """Curriculum terms based on locomotion performance/ traveled distance."""
 
 from __future__ import annotations
 
 import math
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
 import torch
 
@@ -27,7 +28,9 @@ from isaaclab.envs.mdp.actions import RelativeJointPositionAction
 from isaaclab.managers import EventTermCfg, ManagerTermBase, SceneEntityCfg
 from isaaclab.terrains import TerrainImporter
 
-from agile.rl_env.mdp import HarnessAction, LiftAction
+from agile.rl_env.mdp import HarnessAction
+
+Direction: TypeAlias = Literal["above", "below"]
 
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
@@ -152,12 +155,16 @@ class terrain_levels_standing_at_timeout(ManagerTermBase):
 
     This curriculum is designed for stand-up tasks where success is defined as
     being at standing height when the episode ends due to timeout (not early termination).
+
+    Supports an optional prerequisite curriculum that must reach a threshold before
+    this curriculum becomes active.
     """
 
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
         super().__init__(cfg, env)
         self.num_failures = torch.zeros(env.num_envs, device=env.device, dtype=torch.int32)
         self.num_successes = torch.zeros(env.num_envs, device=env.device, dtype=torch.int32)
+        self._activated = False
 
     def __call__(
         self,
@@ -168,6 +175,9 @@ class terrain_levels_standing_at_timeout(ManagerTermBase):
         sensor_cfg: SceneEntityCfg | None = None,
         n_failures: int = 3,
         n_successes: int = 3,
+        prerequisite_curriculum: str | None = None,
+        prerequisite_threshold: float = 0.0,
+        prerequisite_direction: Direction = "below",
     ) -> torch.Tensor:
         """Curriculum based on standing at timeout.
 
@@ -182,12 +192,34 @@ class terrain_levels_standing_at_timeout(ManagerTermBase):
             sensor_cfg: Optional height sensor for rough terrain adjustment.
             n_failures: Number of failures before moving to easier terrain.
             n_successes: Number of successes before moving to harder terrain.
+            prerequisite_curriculum: Name of another curriculum that must reach threshold
+                before this one activates. If None, this curriculum is always active.
+            prerequisite_threshold: The threshold value the prerequisite must reach.
+            prerequisite_direction: "below" means prerequisite must be <= threshold,
+                "above" means prerequisite must be >= threshold.
 
         Returns:
             The mean terrain level for the given environment ids.
         """
-
         terrain: TerrainImporter = env.scene.terrain
+
+        # Check prerequisite curriculum if configured (only until first activation)
+        if not self._activated and prerequisite_curriculum is not None:
+            prereq_value = env.curriculum_manager._curriculum_state.get(prerequisite_curriculum)
+            if prereq_value is None:
+                return 0.0
+
+            if prerequisite_direction == "below":
+                prereq_met = prereq_value <= prerequisite_threshold
+            else:  # "above"
+                prereq_met = prereq_value >= prerequisite_threshold
+
+            if not prereq_met:
+                # Prerequisite not met, don't update terrain levels
+                return torch.mean(terrain.terrain_levels.float())
+
+            # Prerequisite met for the first time, activate permanently
+            self._activated = True
 
         # Check if these envs timed out
         is_timeout = env.termination_manager.time_outs[env_ids]
@@ -209,6 +241,118 @@ class terrain_levels_standing_at_timeout(ManagerTermBase):
 
         self.num_successes[env_ids] += succeeded
         self.num_failures[env_ids] += ~succeeded
+
+        move_up = self.num_successes[env_ids] >= n_successes
+        move_down = self.num_failures[env_ids] >= n_failures
+
+        # Reset counters when moving up or down
+        self.num_failures[env_ids[move_up | move_down]] = 0
+        self.num_successes[env_ids[move_up | move_down]] = 0
+
+        terrain.update_env_origins(env_ids, move_up, move_down)
+        return torch.mean(terrain.terrain_levels.float())
+
+
+class terrain_levels_tracking_at_timeout(ManagerTermBase):
+    """Curriculum based on height command tracking error when the episode times out.
+
+    Designed for height-tracking tasks: success is defined as having low tracking
+    error at timeout, rather than reaching a fixed standing height.
+
+    Supports an optional prerequisite curriculum that must reach a threshold before
+    this curriculum becomes active.
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self.num_failures = torch.zeros(env.num_envs, device=env.device, dtype=torch.int32)
+        self.num_successes = torch.zeros(env.num_envs, device=env.device, dtype=torch.int32)
+        self._activated = False
+        self._command_term = env.command_manager.get_term(cfg.params["command_name"])
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: torch.Tensor,
+        command_name: str,  # noqa: ARG002
+        error_threshold: float = 0.1,
+        n_failures: int = 3,
+        n_successes: int = 3,
+        ignore_terminations: bool = False,
+        prerequisite_curriculum: str | None = None,
+        prerequisite_threshold: float = 0.0,
+        prerequisite_direction: Direction = "below",
+        error_metric_name: str = "height_error",
+    ) -> torch.Tensor:
+        """Curriculum based on tracking error at timeout.
+
+        The robot moves to harder terrain if tracking error is below threshold at
+        timeout `n_successes` times, and to easier terrain if it fails `n_failures` times.
+
+        Args:
+            env: The environment.
+            env_ids: The environment IDs that are being reset.
+            command_name: Name of the command term.
+            error_threshold: Max tracking error (meters) to count as success.
+            n_failures: Number of failures before moving to easier terrain.
+            n_successes: Number of successes before moving to harder terrain.
+            ignore_terminations: If True, episodes that end via early termination
+                (not timeout) are ignored — they don't count as success or failure.
+                If False (default), non-timeout episodes count as failures.
+            prerequisite_curriculum: Name of another curriculum that must reach threshold
+                before this one activates. If None, this curriculum is always active.
+            prerequisite_threshold: The threshold value the prerequisite must reach.
+            prerequisite_direction: "below" means prerequisite must be <= threshold,
+                "above" means prerequisite must be >= threshold.
+            error_metric_name: Name of the error metric in command_term.metrics to use.
+
+        Returns:
+            The mean terrain level for the given environment ids.
+        """
+        terrain: TerrainImporter = env.scene.terrain
+
+        # Check prerequisite curriculum if configured (only until first activation)
+        if not self._activated and prerequisite_curriculum is not None:
+            prereq_value = env.curriculum_manager._curriculum_state.get(prerequisite_curriculum)
+            if prereq_value is None:
+                return 0.0
+
+            if prerequisite_direction == "below":
+                prereq_met = prereq_value <= prerequisite_threshold
+            else:  # "above"
+                prereq_met = prereq_value >= prerequisite_threshold
+
+            if not prereq_met:
+                return torch.mean(terrain.terrain_levels.float())
+
+            # Prerequisite met for the first time, activate permanently
+            self._activated = True
+
+        # Check if these envs timed out
+        is_timeout = env.termination_manager.time_outs[env_ids]
+
+        # If ignoring terminations, only evaluate envs that timed out
+        if ignore_terminations:
+            timeout_mask = is_timeout.nonzero(as_tuple=False).squeeze(-1)
+            if timeout_mask.numel() == 0:
+                return torch.mean(terrain.terrain_levels.float())
+            eval_ids = env_ids[timeout_mask]
+
+            mean_error = self._command_term.metrics[error_metric_name][eval_ids]
+            is_tracking_well = mean_error < error_threshold
+
+            self.num_successes[eval_ids] += is_tracking_well
+            self.num_failures[eval_ids] += ~is_tracking_well
+        else:
+            # Check episode-average tracking error for these envs
+            mean_error = self._command_term.metrics[error_metric_name][env_ids]
+            is_tracking_well = mean_error < error_threshold
+
+            # Success = timeout AND low average tracking error
+            succeeded = is_timeout & is_tracking_well
+
+            self.num_successes[env_ids] += succeeded
+            self.num_failures[env_ids] += ~succeeded
 
         move_up = self.num_successes[env_ids] >= n_successes
         move_down = self.num_failures[env_ids] >= n_failures
@@ -328,107 +472,333 @@ def remove_harness(
         return scale  # type: ignore
 
 
-class adaptive_lift_curriculum(ManagerTermBase):
-    """Adaptive curriculum that adjusts lift forces based on whether robots learn to stand up.
+def _check_prerequisite(
+    env: ManagerBasedRLEnv,
+    prerequisite_curriculum: str | None,
+    prerequisite_threshold: float,
+    prerequisite_direction: Direction,
+) -> bool:
+    """Check if a prerequisite curriculum condition is met.
 
-    This curriculum tracks the MAXIMUM height reached during each episode, not the height
-    at termination. This decouples "learning to stand up" from "learning to balance":
-    - Standing up = reaching standing height at any point during the episode
-    - Balancing = staying up after standing (separate skill, doesn't need lift)
+    Returns True if the prerequisite is satisfied or not configured.
+    """
+    if prerequisite_curriculum is None:
+        return True
+    prereq_value = env.curriculum_manager._curriculum_state.get(prerequisite_curriculum)
+    if prereq_value is None:
+        return False
+    if prerequisite_direction == "below":
+        return bool(prereq_value <= prerequisite_threshold)
+    return bool(prereq_value >= prerequisite_threshold)
 
-    If enough robots managed to stand up at least once during their episode, the lift
-    forces are reduced. This provides better RL guidance because:
-    - Robots aren't punished for attempting to stand and then falling
-    - The lift helps with learning to stand up, not with balancing
-    - Once the robot can reach standing height, the lift's job is done
 
-    The curriculum uses EMA smoothing to reduce noise from individual episodes.
+class adaptive_force_decay(ManagerTermBase):
+    """Adaptive curriculum that decays action forces based on a performance metric.
+
+    Monitors a metric, smooths it with EMA, and multiplicatively decays the force
+    scale when the smoothed metric crosses a threshold. The force scale is
+    monotonically non-increasing: once decayed, it never increases again.
+
+    Supported ``metric_name`` values:
+
+    - ``"standing_ratio"``: Fraction of envs reaching standing height (from
+      ``action.max_heights``). Requires ``standing_height_threshold``.
+    - ``"velocity_xy"``: Instantaneous velocity tracking error norm (L2).
+      Evaluated every step on all envs. Requires ``command_name``.
+    - Any key in ``command_term.metrics`` (e.g. ``"height_error"``):
+      Per-episode metric read at env reset. Requires ``command_name``.
+
+    Any action with a ``scale_forces(float)`` method is supported (e.g.,
+    LiftAction, HarnessAction, CommandAssistAction). Use ``scale_method``
+    to target a specific component (e.g., ``"scale_velocity"``,
+    ``"scale_height"``).
     """
 
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
         super().__init__(cfg, env)
-        self._standing_ratio_ema = 0.0
-        self._force_scale = 1.0
+        self._force_scale: float = 1.0
+        self._action = env.action_manager._terms[cfg.params["action_name"]]
+        self._scale_method: str = cfg.params.get("scale_method", "scale_forces")
 
-        # Get the lift action reference (which tracks max heights)
-        self._lift_action: LiftAction = env.action_manager._terms[cfg.params["lift_action_name"]]
+        decay_when = cfg.params.get("decay_when", "above")
+        self._ema: float = 0.0 if decay_when == "above" else 1.0
+
+        if "command_name" in cfg.params:
+            self._command_term = env.command_manager.get_term(cfg.params["command_name"])
 
     def __call__(
         self,
-        env: ManagerBasedRLEnv,  # noqa: ARG002
+        env: ManagerBasedRLEnv,
         env_ids: torch.Tensor,
-        lift_action_name: str,  # noqa: ARG002
-        standing_height_threshold: float,
-        standing_ratio_to_decrease: float = 0.8,
-        standing_ratio_to_increase: float = 0.6,
+        action_name: str,  # noqa: ARG002
+        metric_name: str = "standing_ratio",
+        decay_when: Direction = "above",
+        threshold: float = 0.8,
         ema_alpha: float = 0.01,
-        epsilon: float = 0.001,
-        force_scale_disable_threshold: float = 0.01,
-        force_scale_reenable_value: float = 0.1,
-        only_decrease: bool = False,
+        decay: float = 0.999,
+        disable_threshold: float = 0.01,
+        # Metric-specific (used at init or by specific metrics)
+        command_name: str | None = None,  # noqa: ARG002
+        standing_height_threshold: float = 0.7,
+        # Scale method
+        scale_method: str = "scale_forces",  # noqa: ARG002
+        # Prerequisite
+        prerequisite_curriculum: str | None = None,
+        prerequisite_threshold: float = 0.0,
+        prerequisite_direction: Direction = "below",
     ) -> float:
-        """Update lift force scale based on whether robots stood up during their episode.
+        """Update force scale based on smoothed metric.
 
         Args:
             env: The learning environment.
-            env_ids: Environment IDs that are being reset.
-            lift_action_name: Name of the lift action term.
-            standing_height_threshold: Height above which robot counts as having "stood up".
-            standing_ratio_to_decrease: Decrease forces if EMA > this (hysteresis upper).
-            standing_ratio_to_increase: Increase forces if EMA < this (hysteresis lower).
-                Ignored if only_decrease=True.
-            ema_alpha: Smoothing factor for standing ratio EMA. Smaller = smoother.
-            epsilon: Adjustment rate per update. Force scale *= (1 - epsilon).
-            force_scale_disable_threshold: Set scale to 0 when it drops below this.
-            force_scale_reenable_value: Set scale to this when re-enabling from 0.
-                Ignored if only_decrease=True.
-            only_decrease: If True, forces can only decrease, never increase.
-                The curriculum becomes one-way: once reduced, it stays reduced.
+            env_ids: Environment IDs being reset (unused for ``"velocity_xy"``).
+            action_name: Name of the action term to control (used at init).
+            metric_name: Which metric to monitor. ``"standing_ratio"`` uses
+                ``action.max_heights``; ``"velocity_xy"`` computes velocity error
+                every step; anything else reads from ``command_term.metrics``.
+            decay_when: ``"above"`` decays when EMA exceeds threshold (e.g. high
+                standing ratio means robot learned). ``"below"`` decays when EMA
+                drops below threshold (e.g. low error means robot learned).
+            threshold: The value the EMA must cross to trigger decay.
+            ema_alpha: EMA smoothing factor. Smaller = smoother.
+            decay: Multiplicative decay per step. Scale ``*= decay``.
+            disable_threshold: Set scale to 0 when it drops below this.
+            command_name: Command term name (used at init for error metrics).
+            standing_height_threshold: Min height to count as standing
+                (``"standing_ratio"`` only).
+            prerequisite_curriculum: Name of another curriculum that must reach a
+                threshold before this one starts decaying.
+            prerequisite_threshold: The threshold the prerequisite must reach.
+            prerequisite_direction: ``"below"`` = ``<= threshold``,
+                ``"above"`` = ``>= threshold``.
 
         Returns:
             Current force scale [0, 1].
         """
-        if len(env_ids) == 0:
+        if self._force_scale <= 0:
+            return 0.0
+
+        # Per-step metrics run every step; per-episode metrics skip when no envs reset
+        per_step_metrics = {"velocity_xy", "yaw_error", "orientation_error", "height_error"}
+        if metric_name not in per_step_metrics and len(env_ids) == 0:
             return self._force_scale
 
-        # Get max heights achieved during the episodes that just ended
-        # (tracked by the lift action every step)
-        max_heights = self._lift_action.max_heights[env_ids]
+        if not _check_prerequisite(env, prerequisite_curriculum, prerequisite_threshold, prerequisite_direction):
+            return self._force_scale
 
-        # Count how many robots managed to stand up at least once
-        stood_up_mask = max_heights > standing_height_threshold
-        num_episodes = len(env_ids)
-        num_stood_up = stood_up_mask.sum().item()
+        # Compute metric
+        if metric_name == "standing_ratio":
+            metric = float((self._action.max_heights[env_ids] > standing_height_threshold).float().mean().item())
+        elif metric_name == "velocity_xy":
+            cmd_vel_xy = self._command_term.command[:, :2]
+            # Use smoothed velocity from the command term (if available) so that
+            # jerky high-frequency oscillations don't keep the assist alive.
+            if hasattr(self._command_term, "vel_xy_smoothed"):
+                cur_vel_xy = self._command_term.vel_xy_smoothed
+            else:
+                cur_vel_xy = env.scene["robot"].data.root_lin_vel_b[:, :2]
+            metric = float(torch.norm(cmd_vel_xy - cur_vel_xy, dim=1).mean().item())
+        elif metric_name == "yaw_error":
+            cmd_yaw = self._command_term.command[:, 2]
+            # Use the smoothed yaw rate from the assist action (if available) so that
+            # jerky high-frequency oscillations don't keep the assist alive.
+            if hasattr(self._action, "_yaw_rate_smoothed"):
+                cur_yaw = self._action._yaw_rate_smoothed
+            else:
+                cur_yaw = env.scene["robot"].data.root_ang_vel_w[:, 2]
+            metric = float(torch.abs(cmd_yaw - cur_yaw).mean().item())
+        elif metric_name == "orientation_error":
+            gravity = env.scene["robot"].data.projected_gravity_b  # (N, 3)
+            # Roll/pitch error from upright: projected gravity should be (0, 0, -1)
+            metric = float(torch.norm(gravity[:, :2], dim=1).mean().item())
+        elif metric_name == "height_error" and hasattr(self._command_term, "base_height"):
+            metric = float(torch.abs(self._command_term.base_height - self._command_term.target_height).mean().item())
+        else:
+            metric = float(self._command_term.metrics[metric_name][env_ids].mean().item())
 
-        # Calculate standing ratio for this batch
-        standing_ratio = num_stood_up / num_episodes
+        # EMA update
+        self._ema = ema_alpha * metric + (1 - ema_alpha) * self._ema
 
-        # Update EMA
-        self._standing_ratio_ema = ema_alpha * standing_ratio + (1 - ema_alpha) * self._standing_ratio_ema
+        # Decay when metric crosses threshold
+        should_decay = self._ema > threshold if decay_when == "above" else self._ema < threshold
+        if should_decay:
+            self._force_scale *= decay
+            if self._force_scale < disable_threshold:
+                self._force_scale = 0.0
 
-        # Adjust force scale based on standing ratio
-        if self._standing_ratio_ema > standing_ratio_to_decrease:
-            # Robots are learning to stand up, reduce forces
-            if self._force_scale > 0:
-                self._force_scale *= 1 - epsilon
-                # Check if below threshold, disable entirely
-                if self._force_scale < force_scale_disable_threshold:
+        getattr(self._action, self._scale_method)(self._force_scale)
+        return self._force_scale
+
+
+class goal_pose_force_decay(ManagerTermBase):
+    """Global decay of assist forces based on success rate at command interval completion.
+
+    Detects when envs complete a command interval (time-based resampling, excluding
+    episode resets) and checks the terminal error from the previous step. Decays the
+    global force scale when the fraction of successful completions (error < threshold)
+    exceeds ``success_rate``.
+
+    With 4096 envs and 5-10s intervals, ~10 envs complete per step, giving a reliable
+    per-step success rate estimate. The decay fires at most once per step regardless
+    of how many envs complete, so the rate is independent of ``num_envs``.
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self._force_scale: float = 1.0
+        self._action = env.action_manager._terms[cfg.params["action_name"]]
+        self._scale_method: str = cfg.params.get("scale_method", "scale_forces")
+        self._metric_name: str = cfg.params["metric_name"]
+        self._command_term = env.command_manager.get_term(cfg.params["command_name"])
+        self._dt: float = env.step_dt
+
+        # Previous step state — large init prevents spurious detection on first step
+        self._prev_time_left = torch.full((env.num_envs,), 1e6, device=env.device)
+        self._prev_metric = torch.zeros(env.num_envs, device=env.device)
+
+    def _get_metric(self, env: ManagerBasedRLEnv) -> torch.Tensor:
+        """Get the per-env metric tensor."""
+        if self._metric_name == "orientation_error":
+            gravity = env.scene["robot"].data.projected_gravity_b
+            return torch.norm(gravity[:, :2], dim=1)
+        return self._command_term.metrics[self._metric_name]
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: torch.Tensor,
+        action_name: str,  # noqa: ARG002
+        command_name: str,  # noqa: ARG002
+        metric_name: str,  # noqa: ARG002
+        threshold: float = 0.5,
+        decay: float = 0.9999,
+        success_rate: float = 0.8,
+        scale_method: str = "scale_forces",  # noqa: ARG002
+        disable_threshold: float = 0.01,
+    ) -> float:
+        if self._force_scale <= 0:
+            return 0.0
+
+        time_left = self._command_term.time_left
+
+        # Detect command interval completions: time_left jumped up (resampled)
+        resampled = time_left > self._prev_time_left + self._dt
+
+        # Exclude episode resets — those are not successful interval completions
+        reset_mask = torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+        if len(env_ids) > 0:
+            reset_mask[env_ids] = True
+        completed = resampled & ~reset_mask
+
+        if completed.any():
+            terminal_error = self._prev_metric[completed].abs()
+            rate = (terminal_error < threshold).float().mean().item()
+            if rate >= success_rate:
+                self._force_scale *= decay
+                if self._force_scale < disable_threshold:
                     self._force_scale = 0.0
 
-        elif not only_decrease and self._standing_ratio_ema < standing_ratio_to_increase:
-            # Struggling and allowed to increase forces
-            if self._force_scale == 0:
-                # Re-enable from zero
-                self._force_scale = force_scale_reenable_value
-            else:
-                self._force_scale *= 1 + epsilon
-                # Clamp to max of 1.0
-                self._force_scale = min(self._force_scale, 1.0)
+        # Store current state for next step
+        self._prev_time_left[:] = time_left
+        self._prev_metric[:] = self._get_metric(env)
 
-        # Apply the updated scale to the lift action
-        self._lift_action.scale_forces(self._force_scale)
-
+        getattr(self._action, self._scale_method)(self._force_scale)
         return self._force_scale
+
+
+class goal_distance_curriculum(ManagerTermBase):
+    """Bidirectional curriculum for goal XY distance with hysteresis.
+
+    Detects when envs complete a command interval (time-based resampling,
+    excluding episode resets) and checks the terminal position error.
+
+    - **Grow** when success rate >= ``success_rate`` (default 0.8)
+    - **Shrink** when success rate < ``shrink_success_rate`` (default 0.4)
+    - **Hold** in between (hysteresis dead zone prevents oscillation)
+
+    The shrink rate is ``shrink_factor * increment`` so the curriculum backs off
+    quickly when other curriculums (e.g. assist decay) make the task harder.
+
+    The lower bound of ``pos_radius`` stays at 0 so the policy always sees a mix
+    of easy and hard goals, which stabilises value function learning.
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self._command_term = env.command_manager.get_term(cfg.params["command_name"])
+        self._dt: float = env.step_dt
+
+        # Curriculum state
+        self._current_max_radius: float = cfg.params.get("initial_max_radius", 0.5)
+        self._min_radius: float = cfg.params.get("initial_max_radius", 0.5)
+        self._locked: bool = False  # Once max is reached, lock and never shrink back
+
+        # Apply initial range immediately
+        self._command_term.cfg.ranges.pos_radius = (0.0, self._current_max_radius)
+
+        # Previous step state
+        self._prev_time_left = torch.full((env.num_envs,), 1e6, device=env.device)
+        self._prev_metric = torch.zeros(env.num_envs, device=env.device)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: torch.Tensor,
+        command_name: str,  # noqa: ARG002
+        initial_max_radius: float = 0.5,  # noqa: ARG002
+        max_radius: float = 5.0,
+        increment: float = 0.1,
+        threshold: float = 0.3,
+        success_rate: float = 0.8,
+        shrink_success_rate: float = 0.4,
+        shrink_factor: float = 2.0,
+        lock_at_max: bool = True,
+    ) -> float:
+        """Adjust goal radius based on tracking performance.
+
+        Args:
+            command_name: Name of the humanoid pose command term.
+            initial_max_radius: Starting max radius (used in __init__ only).
+            max_radius: Upper cap for the goal radius.
+            increment: Additive increase per successful batch.
+            threshold: Position error (m) below which a completion counts as success.
+            success_rate: Fraction above which radius grows.
+            shrink_success_rate: Fraction below which radius shrinks.
+            shrink_factor: Multiplier on ``increment`` for shrink speed.
+            lock_at_max: If True, once max_radius is reached, never shrink back.
+
+        Returns:
+            Current maximum goal radius.
+        """
+        time_left = self._command_term.time_left
+
+        # Detect command interval completions: time_left jumped up (resampled)
+        resampled = time_left > self._prev_time_left + self._dt
+
+        # Exclude episode resets
+        reset_mask = torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+        if len(env_ids) > 0:
+            reset_mask[env_ids] = True
+        completed = resampled & ~reset_mask
+
+        if completed.any() and not self._locked:
+            terminal_error = self._prev_metric[completed].abs()
+            rate = (terminal_error < threshold).float().mean().item()
+            if rate >= success_rate and self._current_max_radius < max_radius:
+                self._current_max_radius = min(self._current_max_radius + increment, max_radius)
+                self._command_term.cfg.ranges.pos_radius = (0.0, self._current_max_radius)
+                # Lock once max is reached so disturbance curriculum can take over
+                if lock_at_max and self._current_max_radius >= max_radius:
+                    self._locked = True
+            elif rate < shrink_success_rate and self._current_max_radius > self._min_radius:
+                self._current_max_radius = max(self._current_max_radius - increment * shrink_factor, self._min_radius)
+                self._command_term.cfg.ranges.pos_radius = (0.0, self._current_max_radius)
+
+        # Store current state for next step
+        self._prev_time_left[:] = time_left
+        self._prev_metric[:] = self._command_term.metrics["torso_position_error"]
+
+        return self._current_max_radius
 
 
 class update_event_range_step(ManagerTermBase):
@@ -513,6 +883,109 @@ class update_event_range_step(ManagerTermBase):
             return scale
 
 
+class velocity_command_range_step(ManagerTermBase):
+    """Linearly interpolate velocity command ranges over a fixed number of training steps.
+
+    Directly modifies the command term's ranges (lin_vel_x, lin_vel_y, ang_vel_z)
+    from start_ranges to terminal_ranges between start_step and start_step + num_steps.
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self.command_name = cfg.params["command_name"]
+        self.start_ranges = cfg.params["start_ranges"]
+        self.terminal_ranges = cfg.params["terminal_ranges"]
+        command = env.command_manager._terms[self.command_name]
+        for attr, (lo, hi) in self.start_ranges.items():
+            setattr(command.cfg.ranges, attr, (lo, hi))
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        command_name: str,  # noqa: ARG002
+        start_ranges: dict[str, tuple[float, float]],  # noqa: ARG002
+        terminal_ranges: dict[str, tuple[float, float]],  # noqa: ARG002
+        start_step: int,
+        num_steps: int,
+    ) -> float:
+        if env.common_step_counter <= start_step:
+            return 0.0
+
+        scale: float = min((env.common_step_counter - start_step) / num_steps, 1.0)
+        command = env.command_manager._terms[self.command_name]
+        for attr in self.start_ranges:
+            s = self.start_ranges[attr]
+            t = self.terminal_ranges[attr]
+            new_range = (s[0] + (t[0] - s[0]) * scale, s[1] + (t[1] - s[1]) * scale)
+            setattr(command.cfg.ranges, attr, new_range)
+        return scale
+
+
+class update_event_param_after_curriculum(ManagerTermBase):
+    """Ramp an event parameter after a prerequisite curriculum is met.
+
+    Supports scalars (e.g., random_fallen_ratio: 0.0 → 0.5),
+    tuples (e.g., force_range: (-5, 5) → (-20, 20)),
+    and dicts of tuples (e.g., velocity_range: {"x": (-0.1, 0.1), ...}).
+
+    If ``start_value`` is provided, interpolates from it to ``terminal_value``.
+    If omitted, defaults to ``0.0`` (scalar ramp from zero).
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        self._trigger_step: int | None = None
+        self._start_value = cfg.params.get("start_value", 0.0)
+
+        # Apply initial value to the event term immediately.
+        event_term = cfg.params["event_term"]
+        param_name = cfg.params["param_name"]
+        env.event_manager.get_term_cfg(event_term).params[param_name] = self._start_value
+
+    def _interpolate(self, start: Any, terminal: Any, scale: float) -> Any:
+        """Recursively interpolate between start and terminal. Handles scalars, tuples, and dicts."""
+        if isinstance(start, dict):
+            return {k: self._interpolate(start[k], terminal[k], scale) for k in start}
+        if isinstance(start, tuple | list):
+            return type(start)(s + (t - s) * scale for s, t in zip(start, terminal, strict=False))
+        return start + (terminal - start) * scale
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        event_term: str,
+        param_name: str,
+        terminal_value: Any,
+        prerequisite_curriculum: str,
+        prerequisite_threshold: float,
+        delay_steps: int,
+        num_steps: int,
+        start_value: Any = None,  # noqa: ARG002 — read from self._start_value
+    ) -> float:
+        """Ramp event param after prerequisite is met.
+
+        Returns:
+            Current interpolation scale (0.0 to 1.0).
+        """
+        if self._trigger_step is None:
+            prereq_value = env.curriculum_manager._curriculum_state.get(prerequisite_curriculum)
+            if prereq_value is not None and prereq_value >= prerequisite_threshold:
+                self._trigger_step = env.common_step_counter
+            else:
+                return 0.0
+
+        ramp_start = self._trigger_step + delay_steps
+        if env.common_step_counter <= ramp_start:
+            return 0.0
+
+        scale = min((env.common_step_counter - ramp_start) / num_steps, 1.0)
+        new_value = self._interpolate(self._start_value, terminal_value, scale)
+        env.event_manager.get_term_cfg(event_term).params[param_name] = new_value
+        return float(scale)
+
+
 class update_reward_weight_step(ManagerTermBase):
     """Curriculum to update reward weights given the iteration."""
 
@@ -590,3 +1063,271 @@ class update_reward_weight_step(ManagerTermBase):
 
             env.reward_manager.get_term_cfg(reward_name).weight = new_weight
             return new_weight
+
+
+class update_reward_weight_after_curriculum(ManagerTermBase):
+    """Curriculum that ramps a reward weight after a prerequisite curriculum reaches a threshold.
+
+    Once the prerequisite is met, waits `delay_steps`, then ramps the reward
+    weight from its current value to `terminal_weight` over `num_steps`.
+    Supports linear or log-space interpolation.
+    """
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        reward_name = cfg.params["reward_name"]
+        self.start_weight: float = env.reward_manager.get_term_cfg(reward_name).weight
+        self._trigger_step: int | None = None
+
+        # Validate log space constraints at init time
+        terminal_weight = cfg.params["terminal_weight"]
+        use_log_space = cfg.params.get("use_log_space", False)
+        if use_log_space:
+            if (self.start_weight > 0) != (terminal_weight > 0):
+                raise ValueError(
+                    f"For log space scaling, start_weight ({self.start_weight}) and "
+                    f"terminal_weight ({terminal_weight}) must have the same sign"
+                )
+            if self.start_weight == 0 or terminal_weight == 0:
+                raise ValueError(
+                    f"For log space scaling, weights cannot be zero. "
+                    f"start_weight={self.start_weight}, terminal_weight={terminal_weight}"
+                )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        reward_name: str,
+        prerequisite_curriculum: str,
+        prerequisite_threshold: float,
+        delay_steps: int,
+        num_steps: int,
+        terminal_weight: float,
+        use_log_space: bool = False,
+    ) -> float:
+        """Ramp reward weight after a prerequisite curriculum is satisfied.
+
+        Args:
+            env: The learning environment.
+            env_ids: Not used.
+            reward_name: Reward term to update.
+            prerequisite_curriculum: Name of the curriculum to watch.
+            prerequisite_threshold: Value the prerequisite must reach (>=).
+            delay_steps: Steps to wait after prerequisite is met before ramping.
+            num_steps: Steps over which to ramp to terminal_weight.
+            terminal_weight: Final reward weight.
+            use_log_space: If True, interpolate in log space (both weights must have same sign).
+        """
+        # Check if prerequisite is met
+        if self._trigger_step is None:
+            prereq_value = env.curriculum_manager._curriculum_state.get(prerequisite_curriculum)
+            if prereq_value is not None and prereq_value >= prerequisite_threshold:
+                self._trigger_step = env.common_step_counter
+            else:
+                return self.start_weight
+
+        ramp_start = self._trigger_step + delay_steps
+        if env.common_step_counter <= ramp_start:
+            return self.start_weight
+        elif env.common_step_counter >= ramp_start + num_steps:
+            env.reward_manager.get_term_cfg(reward_name).weight = terminal_weight
+            return terminal_weight
+        else:
+            scale = (env.common_step_counter - ramp_start) / num_steps
+
+            if use_log_space:
+                abs_start = abs(self.start_weight)
+                abs_terminal = abs(terminal_weight)
+                log_weight = math.log(abs_start) + scale * (math.log(abs_terminal) - math.log(abs_start))
+                abs_new_weight = math.exp(log_weight)
+                new_weight = abs_new_weight if self.start_weight > 0 else -abs_new_weight
+            else:
+                new_weight = self.start_weight + (terminal_weight - self.start_weight) * scale
+
+            env.reward_manager.get_term_cfg(reward_name).weight = new_weight
+            return float(new_weight)
+
+
+class update_action_scale_step(ManagerTermBase):
+    """Curriculum to decay the action scale of a joint action term (linear or log-space)."""
+
+    def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        action_name = cfg.params["action_name"]
+        action_term = env.action_manager._terms[action_name]
+        self.start_scale: float = (
+            float(action_term._scale)
+            if isinstance(action_term._scale, int | float)
+            else float(action_term._scale.mean())
+        )
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        action_name: str,
+        start_step: int,
+        num_steps: int,
+        terminal_scale: float,
+        use_log_space: bool = False,
+    ) -> float:
+        """Interpolate the action scale from its initial value to terminal_scale.
+
+        Args:
+            env: The learning environment.
+            env_ids: Not used since all environments are affected.
+            action_name: Name of the action term to update.
+            start_step: Step count at which to begin decaying.
+            num_steps: Number of steps over which to decay.
+            terminal_scale: Final action scale value.
+            use_log_space: If True, interpolate in log space so that equal time
+                intervals produce equal *relative* changes (e.g. 0.1→0.05 takes
+                the same time as 0.05→0.025).
+        """
+        action_term = env.action_manager._terms[action_name]
+
+        if env.common_step_counter <= start_step:
+            return self.start_scale
+        elif env.common_step_counter > start_step + num_steps:
+            action_term._scale = terminal_scale
+            return terminal_scale
+        else:
+            t = (env.common_step_counter - start_step) / num_steps
+            if use_log_space:
+                log_start = math.log(self.start_scale)
+                log_terminal = math.log(terminal_scale)
+                new_scale = math.exp(log_start + t * (log_terminal - log_start))
+            else:
+                new_scale = self.start_scale + (terminal_scale - self.start_scale) * t
+            action_term._scale = new_scale
+            return new_scale
+
+
+def switch_action_to_target_mode(
+    env: ManagerBasedRLEnv,
+    env_ids: Sequence[int],  # noqa: ARG001
+    action_name: str,
+    switch_step: int,
+) -> float:
+    """Switch a SwitchableRelativeJointPositionAction from delta to target mode at a given step.
+
+    Returns 1.0 after switching, 0.0 before.
+    """
+    action_term = env.action_manager._terms[action_name]
+    if env.common_step_counter >= switch_step and not action_term.use_target_mode:
+        action_term.switch_to_target_mode()
+    return float(action_term.use_target_mode)
+
+
+class update_command_bin_distance_step(ManagerTermBase):
+    """Curriculum that increases the max_bin_distance on an EETargetCommand over training."""
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        command_name: str,
+        start_step: int,
+        num_steps: int,
+        start_distance: int,
+        terminal_distance: int,
+    ) -> float:
+        """Linearly interpolate max_bin_distance from start to terminal over num_steps.
+
+        Args:
+            command_name: Name of the EETargetCommand term.
+            start_step: Step to begin increasing.
+            num_steps: Steps over which to ramp.
+            start_distance: Initial max_bin_distance (e.g. 0 = same bin).
+            terminal_distance: Final max_bin_distance (e.g. -1 to disable = full uniform).
+        """
+        command = env.command_manager.get_term(command_name)
+        if env.common_step_counter <= start_step:
+            command.max_bin_distance = start_distance
+            return float(start_distance)
+        elif env.common_step_counter > start_step + num_steps:
+            command.max_bin_distance = terminal_distance
+            return float(terminal_distance)
+        else:
+            scale = (env.common_step_counter - start_step) / num_steps
+            new_dist = int(start_distance + scale * (terminal_distance - start_distance))
+            command.max_bin_distance = new_dist
+            return float(new_dist)
+
+
+class update_command_scalar_step(ManagerTermBase):
+    """Curriculum that linearly ramps a scalar attribute on an EETargetCommand.
+
+    Works for any float attribute: ``pos_delta``, ``ori_delta``, ``box_scale``, etc.
+    """
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        command_name: str,
+        attr_name: str,
+        start_step: int,
+        num_steps: int,
+        start_value: float,
+        terminal_value: float,
+    ) -> float:
+        """Linearly interpolate an attribute from start to terminal over num_steps.
+
+        Args:
+            command_name: Name of the command term.
+            attr_name: Name of the float attribute to modify (e.g. "pos_delta").
+            start_step: Step to begin ramping.
+            num_steps: Steps over which to ramp.
+            start_value: Initial value.
+            terminal_value: Final value.
+        """
+        command = env.command_manager.get_term(command_name)
+        if env.common_step_counter <= start_step:
+            setattr(command, attr_name, start_value)
+            return start_value
+        elif env.common_step_counter > start_step + num_steps:
+            setattr(command, attr_name, terminal_value)
+            return terminal_value
+        else:
+            frac = (env.common_step_counter - start_step) / num_steps
+            new_value = start_value + frac * (terminal_value - start_value)
+            setattr(command, attr_name, new_value)
+            return float(new_value)
+
+
+class update_episode_length_step(ManagerTermBase):
+    """Curriculum that linearly ramps the max episode length (in seconds).
+
+    Modifies ``env.cfg.episode_length_s`` at runtime so the built-in
+    ``time_out`` termination picks up the new horizon automatically.
+    """
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        env_ids: Sequence[int],  # noqa: ARG002
+        start_step: int,
+        num_steps: int,
+        start_length_s: float,
+        terminal_length_s: float,
+    ) -> float:
+        """Linearly interpolate episode length from start to terminal over num_steps.
+
+        Args:
+            start_step: Step to begin ramping.
+            num_steps: Steps over which to ramp.
+            start_length_s: Initial episode length in seconds.
+            terminal_length_s: Final episode length in seconds.
+        """
+        if env.common_step_counter <= start_step:
+            length_s = start_length_s
+        elif env.common_step_counter > start_step + num_steps:
+            length_s = terminal_length_s
+        else:
+            frac = (env.common_step_counter - start_step) / num_steps
+            length_s = start_length_s + frac * (terminal_length_s - start_length_s)
+
+        env.cfg.episode_length_s = length_s
+        return length_s

--- a/agile/rl_env/mdp/events/fallen_state_cache.py
+++ b/agile/rl_env/mdp/events/fallen_state_cache.py
@@ -24,15 +24,20 @@ import os
 
 # Cache format version - increment this when the dataset format changes
 # to invalidate old caches
-_CACHE_VERSION = 3  # v3: Include full terrain config in cache key
+_CACHE_VERSION = 6  # v6: Per-dataset config hashing for dual-dataset support
 
 
-def compute_fallen_state_cache_key(task_name: str, terrain_cfg: dict | None) -> str:
-    """Compute a cache key for fallen states based on task name and terrain config.
+def compute_fallen_state_cache_key(
+    task_name: str, terrain_cfg: dict | None, dataset_cfg_dict: dict | None = None
+) -> str:
+    """Compute a cache key for fallen states based on task name, terrain, and dataset config.
 
     Args:
         task_name: Name of the task (e.g., 'Template-Isaac-Stand-Up-T1-v0')
         terrain_cfg: Terrain generator configuration dictionary (deeply nested)
+        dataset_cfg_dict: Optional dict of dataset-specific parameters that affect
+            the collected states (e.g., spawn_orientation, spawn_joint_mode).
+            When provided, hashed into the cache key to differentiate datasets.
 
     Returns:
         Cache key string suitable for filename
@@ -43,12 +48,19 @@ def compute_fallen_state_cache_key(task_name: str, terrain_cfg: dict | None) -> 
         terrain_str = json.dumps(terrain_cfg, sort_keys=True, default=str)
         terrain_hash = hashlib.md5(terrain_str.encode()).hexdigest()[:8]
     else:
-        terrain_hash = "default"
+        terrain_hash = "flat"
+
+    # Hash dataset config if available
+    if dataset_cfg_dict is not None:
+        dataset_str = json.dumps(dataset_cfg_dict, sort_keys=True, default=str)
+        dataset_hash = hashlib.md5(dataset_str.encode()).hexdigest()[:8]
+    else:
+        dataset_hash = "default"
 
     # Clean task name for filename
     task_clean = task_name.replace("-", "_").replace(" ", "_")
 
-    return f"fallen_states_v{_CACHE_VERSION}_{task_clean}_{terrain_hash}.pt"
+    return f"fallen_states_v{_CACHE_VERSION}_{task_clean}_{terrain_hash}_{dataset_hash}.pt"
 
 
 def get_fallen_state_cache_path(cache_dir: str, cache_key: str) -> str:

--- a/agile/rl_env/mdp/events/fallen_state_dataset.py
+++ b/agile/rl_env/mdp/events/fallen_state_dataset.py
@@ -17,11 +17,10 @@
 
 from __future__ import annotations
 
-import logging
 import math
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import torch
 
@@ -29,8 +28,6 @@ import isaaclab.utils.math as math_utils
 from isaaclab.assets import Articulation
 from isaaclab.terrains import TerrainImporter
 from isaaclab.utils import configclass
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from isaaclab.envs import ManagerBasedRLEnv
@@ -47,14 +44,56 @@ class FallenStateDatasetCfg:
     Each spawn distributes envs uniformly across all terrain types within the level.
     """
 
-    fall_duration_s: float = 2.5
+    fall_duration_s: float = 1.0
     """Duration to simulate falling with disabled joints (long enough for zero velocity)."""
+
+    spawn_height_offset: float = 2.0
+    """Extra height (meters) above default spawn height when dropping robots."""
+
+    spawn_xy_range: float = 3.0
+    """Random xy offset (meters) when spawning. Sampled uniformly from [-range, range] per axis."""
+
+    initial_lin_vel_range: float = 1.0
+    """Maximum linear velocity (m/s) per axis when spawning. Sampled uniformly from [-range, range]."""
+
+    initial_ang_vel_range: float = 1.0
+    """Maximum angular velocity (rad/s) per axis when spawning. Sampled uniformly from [-range, range]."""
+
+    spawn_orientation: Literal["random", "on_back"] = "random"
+    """How to orient robots when spawning for collection.
+
+    'random': Uniform random over SO(3) (default, for general fallen states).
+    'on_back': Lying on back with random yaw (for back-to-standing tasks).
+    """
+
+    spawn_pitch_range: tuple[float, float] = (-1.7, -1.4)
+    """Pitch range in radians for 'on_back' orientation mode. Default centered around -pi/2."""
+
+    spawn_joint_mode: Literal["random", "default"] = "random"
+    """How to initialize joints when spawning.
+
+    'random': Random within soft joint limits (default).
+    'default': Default joint positions with zero velocity.
+    """
 
     cache_enabled: bool = True
     """Whether to enable disk caching of collected states."""
 
     cache_dir: str = "fallen_states_cache"
     """Directory to store cached fallen states."""
+
+    # Stability thresholds to detect and reset exploding robots
+    max_height_above_spawn: float = 1.0
+    """Maximum height above spawn origin before robot is considered unstable (m)."""
+
+    max_lin_vel: float = 20.0
+    """Maximum linear velocity magnitude before robot is considered unstable (m/s)."""
+
+    max_ang_vel: float = 50.0
+    """Maximum angular velocity magnitude before robot is considered unstable (rad/s)."""
+
+    max_joint_vel: float = 100.0
+    """Maximum joint velocity magnitude before robot is considered unstable (rad/s)."""
 
 
 @dataclass
@@ -90,6 +129,7 @@ class FallenStateDataset:
     _num_joints: int = 0
     _device: str = "cpu"
     _terrain_cell_size: tuple[float, float] = (8.0, 8.0)  # Default, will be updated from terrain config
+    _is_flat_terrain: bool = False
 
     def __post_init__(self) -> None:
         self._states_by_level = {}
@@ -117,6 +157,8 @@ class FallenStateDataset:
         simulates falling for fall_duration_s, then captures the final resting state.
         This is repeated num_spawns_per_level times per level.
 
+        For flat terrain (no terrain_generator), uses a single level with no xy offset.
+
         Args:
             env: The environment to collect states from.
             verbose: Whether to print progress information.
@@ -127,24 +169,34 @@ class FallenStateDataset:
 
         self._device = "cpu"  # Store on CPU to save VRAM
         self._num_joints = robot.num_joints
-        self._num_terrain_levels = terrain.cfg.terrain_generator.num_rows
-        self._terrain_cell_size = terrain.cfg.terrain_generator.size
+
+        # Check if using generated terrain or flat plane
+        self._is_flat_terrain = terrain.cfg.terrain_generator is None
+        if self._is_flat_terrain:
+            self._num_terrain_levels = 1
+            self._terrain_cell_size = (100.0, 100.0)  # Large size, won't clamp much
+        else:
+            self._num_terrain_levels = terrain.cfg.terrain_generator.num_rows
+            self._terrain_cell_size = terrain.cfg.terrain_generator.size
 
         # Calculate collection parameters
         dt = env.step_dt
         fall_steps = int(self.cfg.fall_duration_s / dt)
-        num_terrain_types = terrain.terrain_origins.shape[1]
+        num_terrain_types = 1 if self._is_flat_terrain else terrain.terrain_origins.shape[1]
         states_per_level = env.num_envs * self.cfg.num_spawns_per_level
         total_states = states_per_level * self._num_terrain_levels
 
         if verbose:
-            logger.info("[FallenStateDataset] Starting collection:")
-            logger.info(f"  - Terrain grid: {self._num_terrain_levels} levels x {num_terrain_types} types")
-            logger.info(f"  - Num envs: {env.num_envs}")
-            logger.info(f"  - Spawns per level: {self.cfg.num_spawns_per_level}")
-            logger.info(f"  - States per level: {states_per_level}")
-            logger.info(f"  - Total states: {total_states}")
-            logger.info(f"  - Fall duration: {self.cfg.fall_duration_s}s ({fall_steps} steps)")
+            print("[FallenStateDataset] Starting collection:")
+            if self._is_flat_terrain:
+                print("  - Terrain: flat plane (single level)")
+            else:
+                print(f"  - Terrain grid: {self._num_terrain_levels} levels x {num_terrain_types} types")
+            print(f"  - Num envs: {env.num_envs}")
+            print(f"  - Spawns per level: {self.cfg.num_spawns_per_level}")
+            print(f"  - States per level: {states_per_level}")
+            print(f"  - Total states: {total_states}")
+            print(f"  - Fall duration: {self.cfg.fall_duration_s}s ({fall_steps} steps)")
 
         # Initialize storage for all terrain levels
         for level in range(self._num_terrain_levels):
@@ -159,22 +211,50 @@ class FallenStateDataset:
             }
 
         # Disable terminations during collection to allow full falls without interruption
-        # Requires the monkey patch in manager_based_rl_env_patch.py to be active
         env._disable_terminations = True
+
+        # Pre-allocate env ids for joint disabling
+        all_env_ids = torch.arange(env.num_envs, device=env.device)
+        decimation = env.cfg.decimation
+
         try:
             # Collect states for each terrain level
             for level in range(self._num_terrain_levels):
                 if verbose:
-                    logger.info(f"  Collecting level {level + 1}/{self._num_terrain_levels}...")
+                    print(f"  Level {level + 1}/{self._num_terrain_levels}", flush=True)
 
-                for _spawn_idx in range(self.cfg.num_spawns_per_level):
+                level_reset_count = 0
+                for spawn_idx in range(self.cfg.num_spawns_per_level):
                     # Reset envs distributed across terrain columns
                     # With num_envs >> num_cols, all terrain types are covered via modulo wrap-around
                     self._reset_envs_to_terrain_cells(env, level)
 
-                    # Simulate falling for full duration
+                    # Simulate falling for full duration with joints disabled (zero torques)
+                    # We use a manual sim loop to ensure efforts are zeroed before each physics step
                     for _step in range(fall_steps):
-                        env.step(torch.zeros(env.num_envs, env.action_manager.total_action_dim, device=env.device))
+                        if verbose:
+                            progress = f"    Spawn {spawn_idx + 1}/{self.cfg.num_spawns_per_level}, step {_step + 1}/{fall_steps}"
+                            print(f"{progress:<50}", end="\r", flush=True)
+
+                        # Step simulation with disabled joints
+                        for _ in range(decimation):
+                            # Zero out joint efforts before physics (same as disable_joints event)
+                            robot._joint_effort_target_sim[:] = 0.0
+                            robot.root_physx_view.set_dof_actuation_forces(robot._joint_effort_target_sim, all_env_ids)
+                            # Step physics with rendering enabled
+                            env.sim.step()
+
+                        # Update scene after decimation steps
+                        env.scene.update(dt=env.step_dt)
+
+                        # Check for unstable robots and reset them
+                        # They continue falling with remaining steps (no counter restart)
+                        unstable = self._check_unstable_envs(env)
+                        if unstable.any():
+                            reset_ids = torch.where(unstable)[0]
+                            for env_id in reset_ids:
+                                self._reset_single_env(env, env_id.item(), level)
+                            level_reset_count += unstable.sum().item()
 
                     # Capture final resting state (only once at the end)
                     self._capture_states(env, level, terrain)
@@ -183,17 +263,24 @@ class FallenStateDataset:
                 self._finalize_level(level)
 
                 if verbose:
+                    # Clear progress line and print level summary
                     actual = self.get_num_states(level)
-                    logger.info(f"  Level {level + 1} done ({actual} states)")
+                    reset_info = f", {level_reset_count} resets" if level_reset_count > 0 else ""
+                    print(f"    Done: {actual} states{reset_info:<30}")
 
             if verbose:
                 total_states = sum(self.get_num_states(lvl) for lvl in range(self._num_terrain_levels))
-                logger.info(f"[FallenStateDataset] Collection complete: {total_states} total states")
+                print(f"[FallenStateDataset] Collection complete: {total_states} total states")
         finally:
             # Re-enable terminations for normal training
             env._disable_terminations = False
             # Reset terrain levels to 0 (easiest) so training starts from curriculum beginning
-            terrain.terrain_levels[:] = 0
+            # Only for generated terrain - plane terrain doesn't have terrain_levels
+            if not self._is_flat_terrain:
+                terrain.terrain_levels[:] = 0
+            # Re-enable rendering by doing a render step
+            if env.sim.has_gui():
+                env.sim.render()
 
     def _reset_envs_to_terrain_cells(self, env: ManagerBasedRLEnv, level: int) -> None:
         """Reset environments to specific terrain cells with random initial poses.
@@ -206,51 +293,213 @@ class FallenStateDataset:
         robot: Articulation = env.scene["robot"]
         num_envs = env.num_envs
 
-        # terrain_origins has shape (num_levels, num_cols, 3)
-        terrain_origins = terrain.terrain_origins  # (num_levels, num_cols, 3)
-        num_cols = terrain_origins.shape[1]
+        if self._is_flat_terrain:
+            # Flat terrain: use existing env_origins (set by scene), no xy offset
+            # Note: plane terrain doesn't have terrain_levels/terrain_types attributes
+            env_origins = env.scene.env_origins.clone()
+        else:
+            # Generated terrain: distribute across terrain cells
+            terrain_origins = terrain.terrain_origins  # (num_levels, num_cols, 3)
+            num_cols = terrain_origins.shape[1]
 
-        # Update terrain tracking tensors
-        # Envs are distributed across columns via modulo - with num_envs >> num_cols,
-        # all terrain types are covered multiple times per spawn
-        terrain.terrain_levels[:] = level
-        terrain.terrain_types[:] = torch.arange(num_envs, device=env.device) % num_cols
+            # Update terrain tracking tensors
+            terrain.terrain_levels[:] = level
+            terrain.terrain_types[:] = torch.arange(num_envs, device=env.device) % num_cols
 
-        # Get env origins directly from terrain_origins using level and type indices
-        env_origins = terrain_origins[level, terrain.terrain_types.long()]  # (num_envs, 3)
-        env.scene.env_origins[:] = env_origins
+            # Get env origins directly from terrain_origins
+            env_origins = terrain_origins[level, terrain.terrain_types.long()]  # (num_envs, 3)
+            env.scene.env_origins[:] = env_origins
 
-        # Sample random initial poses for falling
+        # Sample initial poses for falling
         root_states = robot.data.default_root_state.clone()
         env_ids = torch.arange(num_envs, device=env.device)
 
-        # Random yaw, roll, pitch
-        yaw = torch.rand(num_envs, device=env.device) * 2 * math.pi - math.pi
-        roll = (torch.rand(num_envs, device=env.device) * 2 - 1) * math.radians(20)
-        pitch = (torch.rand(num_envs, device=env.device) * 2 - 1) * math.radians(20)
-        quat_delta = math_utils.quat_from_euler_xyz(roll, pitch, yaw)
-        root_states[:, 3:7] = math_utils.quat_mul(root_states[:, 3:7], quat_delta)
+        # Set orientation based on spawn mode
+        if self.cfg.spawn_orientation == "on_back":
+            # Lying on back: backward pitch + random yaw
+            pitch = torch.empty(num_envs, device=env.device).uniform_(*self.cfg.spawn_pitch_range)
+            yaw = torch.rand(num_envs, device=env.device) * 2 * math.pi - math.pi
+            roll = torch.zeros(num_envs, device=env.device)
+            quat_delta = math_utils.quat_from_euler_xyz(roll, pitch, yaw)
+            root_states[:, 3:7] = math_utils.quat_mul(root_states[:, 3:7], quat_delta)
+        else:
+            # Uniform random orientation over SO(3) using Shoemake's algorithm
+            u1 = torch.rand(num_envs, device=env.device)
+            u2 = torch.rand(num_envs, device=env.device)
+            u3 = torch.rand(num_envs, device=env.device)
+            sqrt_u1 = torch.sqrt(u1)
+            sqrt_1_minus_u1 = torch.sqrt(1.0 - u1)
+            two_pi_u2 = 2.0 * math.pi * u2
+            two_pi_u3 = 2.0 * math.pi * u3
+            random_quat = torch.stack(
+                [
+                    sqrt_1_minus_u1 * torch.sin(two_pi_u2),
+                    sqrt_1_minus_u1 * torch.cos(two_pi_u2),
+                    sqrt_u1 * torch.sin(two_pi_u3),
+                    sqrt_u1 * torch.cos(two_pi_u3),
+                ],
+                dim=-1,
+            )
+            root_states[:, 3:7] = random_quat
 
-        # Add random linear and angular velocity
-        root_states[:, 7:10] = (torch.rand(num_envs, 3, device=env.device) * 2 - 1) * 5.0  # lin vel
-        root_states[:, 10:13] = (torch.rand(num_envs, 3, device=env.device) * 2 - 1) * 5.0  # ang vel
+        # Add random linear and angular velocity (configurable range)
+        lin_vel_range = self.cfg.initial_lin_vel_range
+        ang_vel_range = self.cfg.initial_ang_vel_range
+        root_states[:, 7:10] = (torch.rand(num_envs, 3, device=env.device) * 2 - 1) * lin_vel_range
+        root_states[:, 10:13] = (torch.rand(num_envs, 3, device=env.device) * 2 - 1) * ang_vel_range
 
         # Set position at env origin (default_root_state has relative offset from origin)
+        # Add configurable extra height to drop from above terrain features
         root_states[:, 0:3] = env_origins + root_states[:, 0:3]
+        root_states[:, 2] += self.cfg.spawn_height_offset
+
+        # Add random xy offset only for generated terrain (not flat)
+        if not self._is_flat_terrain:
+            xy_offset = (torch.rand(num_envs, 2, device=env.device) * 2 - 1) * self.cfg.spawn_xy_range
+            root_states[:, 0:2] += xy_offset
 
         # Write root state
         robot.write_root_pose_to_sim(root_states[:, 0:7], env_ids)
         robot.write_root_velocity_to_sim(root_states[:, 7:13], env_ids)
 
-        # Random joint positions within limits
-        joint_pos_limits = robot.data.soft_joint_pos_limits
-        joint_pos = torch.rand(num_envs, robot.num_joints, device=env.device)
-        joint_pos = joint_pos * (joint_pos_limits[:, :, 1] - joint_pos_limits[:, :, 0]) + joint_pos_limits[:, :, 0]
-        joint_vel = (torch.rand(num_envs, robot.num_joints, device=env.device) * 2 - 1) * 1.0
-        robot.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
+        # Set joint state based on spawn mode
+        if self.cfg.spawn_joint_mode == "default":
+            robot.write_joint_state_to_sim(
+                robot.data.default_joint_pos.clone(),
+                robot.data.default_joint_vel.clone(),
+                env_ids=env_ids,
+            )
+        else:
+            joint_pos_limits = robot.data.soft_joint_pos_limits
+            joint_pos = torch.rand(num_envs, robot.num_joints, device=env.device)
+            joint_pos = joint_pos * (joint_pos_limits[:, :, 1] - joint_pos_limits[:, :, 0]) + joint_pos_limits[:, :, 0]
+            joint_vel = (torch.rand(num_envs, robot.num_joints, device=env.device) * 2 - 1) * 1.0
+            robot.write_joint_state_to_sim(joint_pos, joint_vel, env_ids=env_ids)
 
         # Reset episode counters to enable joint disabling during fall
         env.episode_length_buf[:] = 0
+
+    def _reset_single_env(self, env: ManagerBasedRLEnv, env_id: int, level: int) -> None:
+        """Reset a single environment that became unstable during falling.
+
+        Args:
+            env: The environment.
+            env_id: The environment index to reset.
+            level: The terrain level for this env.
+        """
+        terrain: TerrainImporter = env.scene.terrain
+        robot: Articulation = env.scene["robot"]
+        device = env.device
+
+        if self._is_flat_terrain:
+            # Flat terrain: use existing env_origin
+            env_origin = env.scene.env_origins[env_id]
+        else:
+            # Generated terrain: get origin from terrain grid
+            terrain_origins = terrain.terrain_origins
+            terrain_type = terrain.terrain_types[env_id].long()
+            env_origin = terrain_origins[level, terrain_type]
+            env.scene.env_origins[env_id] = env_origin
+
+        # Sample new initial pose
+        root_state = robot.data.default_root_state[env_id].clone()
+
+        # Set orientation based on spawn mode
+        if self.cfg.spawn_orientation == "on_back":
+            pitch = torch.empty(1, device=device).uniform_(*self.cfg.spawn_pitch_range).squeeze()
+            yaw = torch.rand(1, device=device).squeeze() * 2 * math.pi - math.pi
+            roll = torch.zeros(1, device=device).squeeze()
+            quat_delta = math_utils.quat_from_euler_xyz(
+                roll.unsqueeze(0), pitch.unsqueeze(0), yaw.unsqueeze(0)
+            ).squeeze(0)
+            root_state[3:7] = math_utils.quat_mul(root_state[3:7].unsqueeze(0), quat_delta.unsqueeze(0)).squeeze(0)
+        else:
+            u1, u2, u3 = torch.rand(3, device=device)
+            sqrt_u1 = torch.sqrt(u1)
+            sqrt_1_minus_u1 = torch.sqrt(1.0 - u1)
+            two_pi_u2 = 2.0 * math.pi * u2
+            two_pi_u3 = 2.0 * math.pi * u3
+            random_quat = torch.tensor(
+                [
+                    sqrt_1_minus_u1 * torch.sin(two_pi_u2),
+                    sqrt_1_minus_u1 * torch.cos(two_pi_u2),
+                    sqrt_u1 * torch.sin(two_pi_u3),
+                    sqrt_u1 * torch.cos(two_pi_u3),
+                ],
+                device=device,
+            )
+            root_state[3:7] = random_quat
+
+        # Random velocities
+        root_state[7:10] = (torch.rand(3, device=device) * 2 - 1) * self.cfg.initial_lin_vel_range
+        root_state[10:13] = (torch.rand(3, device=device) * 2 - 1) * self.cfg.initial_ang_vel_range
+
+        # Position at env origin with offset
+        root_state[0:3] = env_origin + root_state[0:3]
+        root_state[2] += self.cfg.spawn_height_offset
+
+        # Add random xy offset only for generated terrain
+        if not self._is_flat_terrain:
+            xy_offset = (torch.rand(2, device=device) * 2 - 1) * self.cfg.spawn_xy_range
+            root_state[0:2] += xy_offset
+
+        # Write root state
+        env_ids_tensor = torch.tensor([env_id], device=device)
+        robot.write_root_pose_to_sim(root_state[0:7].unsqueeze(0), env_ids_tensor)
+        robot.write_root_velocity_to_sim(root_state[7:13].unsqueeze(0), env_ids_tensor)
+
+        # Set joint state based on spawn mode
+        if self.cfg.spawn_joint_mode == "default":
+            robot.write_joint_state_to_sim(
+                robot.data.default_joint_pos[env_id].unsqueeze(0),
+                robot.data.default_joint_vel[env_id].unsqueeze(0),
+                env_ids=env_ids_tensor,
+            )
+        else:
+            joint_pos_limits = robot.data.soft_joint_pos_limits[env_id]
+            joint_pos = torch.rand(robot.num_joints, device=device)
+            joint_pos = joint_pos * (joint_pos_limits[:, 1] - joint_pos_limits[:, 0]) + joint_pos_limits[:, 0]
+            joint_vel = (torch.rand(robot.num_joints, device=device) * 2 - 1) * 1.0
+            robot.write_joint_state_to_sim(joint_pos.unsqueeze(0), joint_vel.unsqueeze(0), env_ids=env_ids_tensor)
+
+    def _check_unstable_envs(self, env: ManagerBasedRLEnv) -> torch.Tensor:
+        """Check which environments have become unstable (exploding physics).
+
+        Args:
+            env: The environment.
+
+        Returns:
+            Boolean tensor of shape (num_envs,) indicating unstable envs.
+        """
+        robot: Articulation = env.scene["robot"]
+
+        # Get current state
+        root_pos_w = robot.data.root_pos_w
+        root_lin_vel = robot.data.root_lin_vel_w
+        root_ang_vel = robot.data.root_ang_vel_w
+        joint_vel = robot.data.joint_vel
+
+        # Check height above spawn position (env_origin + spawn_height_offset)
+        spawn_height = env.scene.env_origins[:, 2] + self.cfg.spawn_height_offset
+        height_above_spawn = root_pos_w[:, 2] - spawn_height
+        too_high = height_above_spawn > self.cfg.max_height_above_spawn
+
+        # Check linear velocity magnitude
+        lin_vel_mag = torch.norm(root_lin_vel, dim=-1)
+        lin_vel_too_high = lin_vel_mag > self.cfg.max_lin_vel
+
+        # Check angular velocity magnitude
+        ang_vel_mag = torch.norm(root_ang_vel, dim=-1)
+        ang_vel_too_high = ang_vel_mag > self.cfg.max_ang_vel
+
+        # Check joint velocity magnitude (max across all joints)
+        joint_vel_mag = torch.abs(joint_vel).max(dim=-1).values
+        joint_vel_too_high = joint_vel_mag > self.cfg.max_joint_vel
+
+        # Combine all checks
+        unstable = too_high | lin_vel_too_high | ang_vel_too_high | joint_vel_too_high
+
+        return unstable
 
     def _capture_states(self, env: ManagerBasedRLEnv, level: int, terrain: TerrainImporter) -> None:
         """Capture current robot states and add to the dataset."""
@@ -265,19 +514,22 @@ class FallenStateDataset:
         # Convert position to relative (relative to env origin / terrain origin)
         root_pos_rel = root_pos_w - env.scene.env_origins
 
-        # Clamp relative position to stay within terrain cell bounds
-        # This prevents issues when robots roll outside their original cell during falling
-        half_size_x = self._terrain_cell_size[0] / 2.0 - 0.5  # Leave 0.5m margin
-        half_size_y = self._terrain_cell_size[1] / 2.0 - 0.5
-        root_pos_rel[:, 0] = torch.clamp(root_pos_rel[:, 0], -half_size_x, half_size_x)
-        root_pos_rel[:, 1] = torch.clamp(root_pos_rel[:, 1], -half_size_y, half_size_y)
+        # Clamp relative position to stay within terrain cell bounds (skip for flat terrain)
+        if not self._is_flat_terrain:
+            half_size_x = self._terrain_cell_size[0] / 2.0 - 0.5  # Leave 0.5m margin
+            half_size_y = self._terrain_cell_size[1] / 2.0 - 0.5
+            root_pos_rel[:, 0] = torch.clamp(root_pos_rel[:, 0], -half_size_x, half_size_x)
+            root_pos_rel[:, 1] = torch.clamp(root_pos_rel[:, 1], -half_size_y, half_size_y)
 
         # Get joint states
         joint_pos = robot.data.joint_pos.clone()
         joint_vel = robot.data.joint_vel.clone()
 
-        # Get terrain type for each env (needed for correct reset)
-        terrain_type = terrain.terrain_types.clone()
+        # Get terrain type for each env (0 for flat terrain)
+        if self._is_flat_terrain:
+            terrain_type = torch.zeros(env.num_envs, dtype=torch.long, device=env.device)
+        else:
+            terrain_type = terrain.terrain_types.clone()
 
         # Store on CPU
         storage = self._states_by_level[level]
@@ -358,10 +610,18 @@ class FallenStateDataset:
             "cfg": {
                 "num_spawns_per_level": self.cfg.num_spawns_per_level,
                 "fall_duration_s": self.cfg.fall_duration_s,
+                "spawn_height_offset": self.cfg.spawn_height_offset,
+                "spawn_xy_range": self.cfg.spawn_xy_range,
+                "initial_lin_vel_range": self.cfg.initial_lin_vel_range,
+                "initial_ang_vel_range": self.cfg.initial_ang_vel_range,
+                "spawn_orientation": self.cfg.spawn_orientation,
+                "spawn_pitch_range": self.cfg.spawn_pitch_range,
+                "spawn_joint_mode": self.cfg.spawn_joint_mode,
             },
             "num_terrain_levels": self._num_terrain_levels,
             "num_joints": self._num_joints,
             "terrain_cell_size": self._terrain_cell_size,
+            "is_flat_terrain": self._is_flat_terrain,
             "states_by_level": self._states_by_level,
         }
         os.makedirs(os.path.dirname(path) if os.path.dirname(path) else ".", exist_ok=True)
@@ -384,8 +644,9 @@ class FallenStateDataset:
             self._num_terrain_levels = save_dict["num_terrain_levels"]
             self._num_joints = save_dict["num_joints"]
             self._terrain_cell_size = save_dict.get("terrain_cell_size", (8.0, 8.0))
+            self._is_flat_terrain = save_dict.get("is_flat_terrain", False)
             self._states_by_level = save_dict["states_by_level"]
             return True
-        except Exception:
-            logger.exception(f"[FallenStateDataset] Failed to load from {path}")
+        except Exception as e:
+            print(f"[FallenStateDataset] Failed to load from {path}: {e}")
             return False

--- a/agile/rl_env/mdp/events/reset_from_fallen_dataset.py
+++ b/agile/rl_env/mdp/events/reset_from_fallen_dataset.py
@@ -52,6 +52,7 @@ class reset_from_fallen_dataset(ManagerTermBase):
         """
         super().__init__(cfg, env)
         self._dataset: FallenStateDataset | None = None
+        self._secondary_dataset: FallenStateDataset | None = None
 
     def set_dataset(self, dataset: FallenStateDataset) -> None:
         """Inject the fallen state dataset after collection.
@@ -61,16 +62,31 @@ class reset_from_fallen_dataset(ManagerTermBase):
         """
         self._dataset = dataset
 
+    def set_secondary_dataset(self, dataset: FallenStateDataset) -> None:
+        """Inject a secondary fallen state dataset (e.g., random orientation).
+
+        Args:
+            dataset: The pre-collected secondary fallen state dataset.
+        """
+        self._secondary_dataset = dataset
+
     @property
     def has_dataset(self) -> bool:
         """Check if a dataset has been set and is collected."""
         return self._dataset is not None and self._dataset.is_collected
+
+    @property
+    def has_secondary_dataset(self) -> bool:
+        """Check if a secondary dataset has been set and is collected."""
+        return self._secondary_dataset is not None and self._secondary_dataset.is_collected
 
     def __call__(
         self,
         env: ManagerBasedRLEnv,
         env_ids: torch.Tensor,
         standing_ratio: float = 0.1,
+        height_offset: float = 0.0,
+        random_fallen_ratio: float = 0.0,
         asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
     ) -> None:
         """Reset environments to sampled fallen states or standing poses.
@@ -79,6 +95,11 @@ class reset_from_fallen_dataset(ManagerTermBase):
             env: The environment instance.
             env_ids: Environment indices to reset.
             standing_ratio: Fraction of envs to reset to standing pose (default 0.1).
+            height_offset: Extra height to add when spawning from dataset (default 0.0).
+                This helps avoid spawning inside rough terrain features.
+            random_fallen_ratio: Fraction of fallen envs to sample from the secondary
+                (random orientation) dataset instead of the primary. Only effective when
+                a secondary dataset has been set. Ramped via curriculum.
             asset_cfg: Asset configuration for the robot.
 
         Raises:
@@ -107,8 +128,33 @@ class reset_from_fallen_dataset(ManagerTermBase):
             if not self.has_dataset:
                 # Dataset not ready (e.g., during collection phase) - fall back to standing
                 self._reset_to_standing(env, fallen_env_ids, asset)
+            elif random_fallen_ratio > 0:
+                if not self.has_secondary_dataset:
+                    raise RuntimeError(
+                        "random_fallen_ratio > 0 but no secondary dataset is set. "
+                        "Configure fallen_state_dataset_secondary_cfg in the agent cfg, "
+                        "or keep random_fallen_ratio at 0."
+                    )
+                # Split fallen envs between primary and secondary datasets
+                secondary_mask = torch.rand(len(fallen_env_ids), device=env.device) < random_fallen_ratio
+                primary_mask = ~secondary_mask
+
+                primary_env_ids = fallen_env_ids[primary_mask]
+                secondary_env_ids = fallen_env_ids[secondary_mask]
+
+                if len(primary_env_ids) > 0:
+                    self._reset_from_dataset(env, primary_env_ids, asset, terrain, height_offset)
+                if len(secondary_env_ids) > 0:
+                    self._reset_from_dataset(
+                        env,
+                        secondary_env_ids,
+                        asset,
+                        terrain,
+                        height_offset,
+                        dataset=self._secondary_dataset,
+                    )
             else:
-                self._reset_from_dataset(env, fallen_env_ids, asset, terrain)
+                self._reset_from_dataset(env, fallen_env_ids, asset, terrain, height_offset)
 
     def _reset_to_standing(
         self,
@@ -150,29 +196,51 @@ class reset_from_fallen_dataset(ManagerTermBase):
         env_ids: torch.Tensor,
         asset: RigidObject | Articulation,
         terrain: TerrainImporter,
+        height_offset: float = 0.0,
+        dataset: FallenStateDataset | None = None,
     ) -> None:
-        """Reset environments to sampled fallen states from dataset."""
-        if self._dataset is None:
+        """Reset environments to sampled fallen states from dataset.
+
+        Args:
+            env: The environment instance.
+            env_ids: Environment indices to reset.
+            asset: The robot asset.
+            terrain: The terrain importer.
+            height_offset: Extra height offset for spawning.
+            dataset: Dataset to sample from. Defaults to the primary dataset.
+        """
+        if dataset is None:
+            dataset = self._dataset
+        if dataset is None:
             raise RuntimeError("Dataset not set. Call set_dataset() before _reset_from_dataset().")
 
-        # Get terrain levels for each env
-        terrain_levels = terrain.terrain_levels[env_ids]
+        # Check if using flat terrain (no terrain_generator)
+        is_flat_terrain = terrain.cfg.terrain_generator is None
+
+        if is_flat_terrain:
+            # Flat terrain: use level 0, keep existing env_origins
+            terrain_levels = torch.zeros(len(env_ids), dtype=torch.long, device=env.device)
+            env_origins = env.scene.env_origins[env_ids]
+        else:
+            # Generated terrain: get levels from terrain
+            terrain_levels = terrain.terrain_levels[env_ids]
 
         # Sample states from dataset (includes terrain_type where state was collected)
-        states = self._dataset.sample(len(env_ids), terrain_levels, device=env.device)
+        states = dataset.sample(len(env_ids), terrain_levels, device=env.device)
 
-        # Update terrain types and env origins to match where states were collected
-        # This ensures the relative position is applied to the correct terrain cell
-        sampled_terrain_types = states["terrain_type"]
-        terrain.terrain_types[env_ids] = sampled_terrain_types
+        if not is_flat_terrain:
+            # Update terrain types and env origins to match where states were collected
+            sampled_terrain_types = states["terrain_type"]
+            terrain.terrain_types[env_ids] = sampled_terrain_types
 
-        # Get the correct env origins from terrain_origins using level and sampled type
-        # terrain_origins has shape (num_levels, num_types, 3)
-        env_origins = terrain.terrain_origins[terrain_levels.long(), sampled_terrain_types.long()]
-        env.scene.env_origins[env_ids] = env_origins
+            # Get the correct env origins from terrain_origins using level and sampled type
+            env_origins = terrain.terrain_origins[terrain_levels.long(), sampled_terrain_types.long()]
+            env.scene.env_origins[env_ids] = env_origins
 
         # Convert relative position to world position using the correct origin
+        # Add height_offset to avoid spawning inside terrain features
         root_pos_w = states["root_pos_rel"] + env_origins
+        root_pos_w[:, 2] += height_offset
 
         # Construct root pose and velocity
         root_pose = torch.cat([root_pos_w, states["root_quat"]], dim=-1)

--- a/agile/rl_env/mdp/rewards/aestetic_rewards.py
+++ b/agile/rl_env/mdp/rewards/aestetic_rewards.py
@@ -13,9 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Literal
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
 
 import torch
+
+if TYPE_CHECKING:
+    from agile.rl_env.mdp.commands.height_command import SmoothHeightCommand
 
 import isaaclab.utils.math as math_utils
 from isaaclab.assets import Articulation, RigidObject
@@ -108,11 +114,175 @@ class body_acc_l2(ManagerTermBase):
         return torch.clamp(torch.sum(torch.square(body_acc), dim=-1), max=1e6)
 
 
-# Alias for backwards compatibility
-root_acc_l2 = body_acc_l2
+def _body_tilt_angles(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+) -> torch.Tensor:
+    """Compute tilt angle from vertical for specified bodies.
+
+    Args:
+        env: Environment instance.
+        asset_cfg: Asset config with body_names specifying which bodies to check.
+            If no body_names, uses root.
+
+    Returns:
+        Tilt angles in radians [num_envs, num_bodies].
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+
+    # Check if specific bodies were requested via body_names
+    if asset_cfg.body_names is None:
+        # Use root
+        cos_theta = torch.clamp(-asset.data.projected_gravity_b[:, 2], -1.0, 1.0)
+        return torch.acos(cos_theta).unsqueeze(-1)  # [num_envs, 1]
+
+    # Get body quaternions and project gravity
+    body_quats = asset.data.body_link_quat_w[:, asset_cfg.body_ids]  # [num_envs, num_bodies, 4]
+    if body_quats.dim() == 2:
+        # Single body case - add body dimension
+        body_quats = body_quats.unsqueeze(1)
+    num_bodies = body_quats.shape[1]
+
+    gravity_vec = asset.data.GRAVITY_VEC_W.unsqueeze(1).expand(-1, num_bodies, -1)
+    projected_gravity = math_utils.quat_apply_inverse(body_quats, gravity_vec)  # [num_envs, num_bodies, 3]
+
+    # Tilt angle: angle between body z-axis and world z-axis (gravity direction)
+    # projected_gravity[:, :, 2] is -1 when upright, +1 when upside down
+    cos_theta = torch.clamp(-projected_gravity[..., 2], -1.0, 1.0)
+    return torch.acos(cos_theta)  # [num_envs, num_bodies]
 
 
-class body_ang_vel_l2(ManagerTermBase):
+class upright_orientation_after_standing(ManagerTermBase):
+    """Penalize non-upright orientation only after standing for a minimum duration.
+
+    Tracks how long each environment has been continuously standing above a height
+    threshold. Only applies the orientation penalty after the robot has been standing
+    for at least `min_standing_duration_s` seconds.
+    """
+
+    def __init__(self, cfg: RewardTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        # Track standing duration for each environment (in seconds)
+        self._standing_duration = torch.zeros(env.num_envs, device=env.device, dtype=torch.float32)
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        standing_height_threshold: float,
+        min_standing_duration_s: float,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+        sensor_cfg: SceneEntityCfg | None = None,
+        norm: Literal["l1", "l2"] = "l1",
+    ) -> torch.Tensor:
+        """Compute orientation penalty only after standing for minimum duration.
+
+        Args:
+            standing_height_threshold: Height above which robot is considered standing.
+            min_standing_duration_s: Minimum standing duration before penalty applies.
+            asset_cfg: Config with body_names for bodies to check (e.g., ["pelvis", "torso_link"]).
+                If no body_names, uses root.
+            sensor_cfg: Optional height sensor config.
+            norm: "l1" returns sum of angles, "l2" returns sum of squared angles.
+        """
+        # Check current standing state
+        is_standing = if_standing(env, standing_height_threshold, asset_cfg, sensor_cfg).bool()
+
+        # Update standing duration: increment if standing, reset if not
+        self._standing_duration[is_standing] += env.step_dt
+        self._standing_duration[~is_standing] = 0.0
+
+        # Only apply penalty if standing for long enough
+        apply_penalty = (self._standing_duration >= min_standing_duration_s).float()
+
+        # Compute orientation penalty (sum over all specified bodies)
+        angles = _body_tilt_angles(env, asset_cfg)  # [num_envs, num_bodies]
+
+        if norm == "l2":
+            penalty = torch.sum(torch.square(angles), dim=-1)
+        else:
+            penalty = torch.sum(angles, dim=-1)
+
+        return penalty * apply_penalty
+
+    def reset(self, env_ids: torch.Tensor) -> None:
+        """Reset standing duration for specified environments."""
+        self._standing_duration[env_ids] = 0.0
+
+
+def severely_tilted_penalty(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    threshold_rad: float = 1.5708,  # 90 degrees
+) -> torch.Tensor:
+    """Penalize when any specified body is tilted beyond threshold from vertical.
+
+    Returns 1.0 if any body exceeds the threshold, 0.0 otherwise.
+    This penalty applies from the start of the episode (not gated by standing).
+
+    Args:
+        env: Environment instance.
+        asset_cfg: Config with body_names for bodies to check (e.g., ["pelvis", "torso_link"]).
+            If no body_names, uses root.
+        threshold_rad: Tilt angle threshold in radians (default: pi/2 = 90 degrees).
+
+    Returns:
+        Binary penalty: 1.0 if any body is severely tilted, 0.0 otherwise.
+    """
+    angles = _body_tilt_angles(env, asset_cfg)  # [num_envs, num_bodies]
+    severely_tilted = (angles > threshold_rad).any(dim=-1)
+    return severely_tilted.float()
+
+
+def body_orientation_penalty(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    axis: Literal["roll", "pitch"] = "roll",
+    direction: Literal["both", "forward", "backward"] = "both",
+    kernel: Literal["l1", "l2"] = "l1",
+) -> torch.Tensor:
+    """Penalize roll or pitch orientation of specified bodies.
+
+    Uses projected gravity in body frame:
+    - Roll = Y-component (positive = lean right, negative = lean left)
+    - Pitch = X-component (positive = lean forward, negative = lean backward)
+
+    Args:
+        env: Environment instance.
+        asset_cfg: Config with body_names for bodies to check.
+        axis: Which axis to penalize: "roll" (Y-component) or "pitch" (X-component).
+        direction: Which direction to penalize:
+            "both" = penalize any deviation (absolute value).
+            "forward" = only penalize positive component (forward pitch / right roll).
+            "backward" = only penalize negative component (backward pitch / left roll).
+        kernel: "l1" for absolute value, "l2" for squared.
+    """
+    asset: Articulation = env.scene[asset_cfg.name]
+
+    body_quats = asset.data.body_link_quat_w[:, asset_cfg.body_ids]
+    if body_quats.dim() == 2:
+        body_quats = body_quats.unsqueeze(1)
+
+    gravity_vec = asset.data.GRAVITY_VEC_W.unsqueeze(1).expand(-1, body_quats.shape[1], -1)
+    projected_gravity = math_utils.quat_apply_inverse(body_quats, gravity_vec)
+
+    component = projected_gravity[..., 0] if axis == "pitch" else projected_gravity[..., 1]
+
+    if direction == "forward":
+        component = torch.clamp(component, min=0.0)
+    elif direction == "backward":
+        component = torch.clamp(-component, min=0.0)
+    else:
+        component = component.abs()
+
+    if kernel == "l2":
+        return torch.mean(component**2, dim=-1)
+    return torch.mean(component, dim=-1)
+
+
+def body_ang_vel_l2(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
     """Penalize body angular velocity using L2 norm.
 
     This reward penalizes high angular velocities of a specified body/link,
@@ -129,45 +299,72 @@ class body_ang_vel_l2(ManagerTermBase):
             weight=-0.01,
             params={"asset_cfg": SceneEntityCfg("robot", body_names=["torso_link"])},
         )
+
+    Args:
+        env: The environment.
+        asset_cfg: Asset configuration. Use body_names to specify a link, otherwise uses root.
+
+    Returns:
+        L2 norm of the body's angular velocity (sum of squared components).
     """
+    # Extract the robot asset
+    robot: Articulation = env.scene[asset_cfg.name]
 
-    def __init__(self, cfg: RewardTermCfg, env: ManagerBasedRLEnv):
-        super().__init__(cfg, env)
+    # Get angular velocity based on whether body_names is specified
+    if asset_cfg.body_ids is not None and len(asset_cfg.body_ids) > 0:
+        # Use specified body angular velocity
+        body_idx = asset_cfg.body_ids[0]
+        ang_vel = robot.data.body_ang_vel_w[:, body_idx, :]  # [num_envs, 3]
+    else:
+        # Default to root angular velocity
+        ang_vel = robot.data.root_ang_vel_w  # [num_envs, 3]
 
-        # Resolve body index if body_names is provided
-        self._body_idx: int | None = None
-        asset_cfg: SceneEntityCfg = cfg.params.get("asset_cfg", SceneEntityCfg("robot"))
-        if asset_cfg.body_names is not None:
-            asset: Articulation = env.scene[asset_cfg.name]
-            self._body_idx = asset.find_bodies(asset_cfg.body_names)[0][0]
+    # Compute L2 penalty (sum of squared angular velocities)
+    return torch.sum(torch.square(ang_vel), dim=-1)
 
-    def __call__(
-        self,
-        env: ManagerBasedRLEnv,
-        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
-    ) -> torch.Tensor:
-        """Compute body angular velocity L2 penalty.
 
-        Args:
-            env: The environment.
-            asset_cfg: Asset configuration. Use body_names to specify a link, otherwise uses root.
+def bodies_lin_vel_l2(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    threshold: float = 0.0,
+) -> torch.Tensor:
+    """Penalize linear velocity magnitude of multiple bodies above a deadzone threshold.
 
-        Returns:
-            L2 norm of the body's angular velocity (sum of squared components).
-        """
-        # Extract the robot asset
-        robot: Articulation = env.scene[asset_cfg.name]
+    Enforces quasi-static motion: all specified body parts should move slowly.
+    Uses 3D velocity magnitude (not just vertical). L2 penalty on excess velocity
+    is summed across all specified bodies.
 
-        # Get angular velocity based on whether body_names is specified
-        if self._body_idx is not None:
-            # Use specified body angular velocity
-            ang_vel = robot.data.body_ang_vel_w[:, self._body_idx, :]  # [num_envs, 3]
-        else:
-            # Default to root angular velocity
-            ang_vel = robot.data.root_ang_vel_w  # [num_envs, 3]
+    Usage:
+        body_velocity = RewTerm(
+            func=bodies_lin_vel_l2,
+            weight=-0.5,
+            params={
+                "asset_cfg": SceneEntityCfg("robot", body_names=[
+                    "pelvis", "torso_link", ".*_hip_.*_link", ".*_knee_link",
+                ]),
+                "threshold": 0.3,  # m/s deadzone
+            },
+        )
 
-        # Compute L2 penalty (sum of squared angular velocities)
-        return torch.sum(torch.square(ang_vel), dim=-1)
+    Args:
+        env: The environment.
+        asset_cfg: Asset configuration with body_names for the bodies to penalize.
+        threshold: Deadzone in m/s. Speeds below this are not penalized.
+
+    Returns:
+        Sum of L2 penalties on velocity magnitude across all specified bodies.
+    """
+    robot: Articulation = env.scene[asset_cfg.name]
+
+    if asset_cfg.body_ids is not None and len(asset_cfg.body_ids) > 0:
+        body_vel = robot.data.body_lin_vel_w[:, asset_cfg.body_ids, :]  # (num_envs, num_bodies, 3)
+        vel_magnitude = torch.norm(body_vel, dim=-1)  # (num_envs, num_bodies)
+        excess = vel_magnitude - threshold
+        return torch.sum(torch.square(torch.clamp(excess, min=0.0)), dim=-1)
+    else:
+        vel_magnitude = torch.norm(robot.data.root_lin_vel_w[:, :3], dim=-1)
+        excess = vel_magnitude - threshold
+        return torch.square(torch.clamp(excess, min=0.0))
 
 
 def if_standing(
@@ -378,16 +575,33 @@ def feet_distance_from_ref(
     ref_distance: float = 0.2,
     command_name: str | None = None,
     lateral_velocity_threshold: float = 0.5,
-    norm: Literal["l1", "l2"] = "l2",
+    norm: Literal["l1", "l2"] = "l1",
+    error_threshold: float = 0.0,
+    distance_mode: Literal["lateral", "absolute"] = "lateral",
+    close_multiplier: float = 1.0,
+    episode_delay_s: float = 0.0,
+    episode_ramp_s: float = 0.0,
 ) -> torch.Tensor:
-    """Penalize feet lateral distance deviation from reference distance.
+    """Penalize feet distance deviation from reference distance.
 
-    This reward encourages maintaining proper lateral spacing between left and right feet.
+    This reward encourages maintaining proper spacing between left and right feet.
 
     Args:
         env: Environment instance.
         asset_cfg: Configuration for the robot asset (should specify foot body names).
-        ref_distance: Reference lateral distance between feet (meters).
+        ref_distance: Reference distance between feet (meters).
+        command_name: Optional velocity command name for lateral velocity gating.
+        lateral_velocity_threshold: Lateral velocity above which penalty is suppressed.
+        norm: "l1" or "l2" kernel.
+        error_threshold: Dead zone — errors within this threshold produce zero penalty.
+        distance_mode: "lateral" uses body-frame Y-axis distance only,
+            "absolute" uses full 3D Euclidean distance between feet in world frame.
+        close_multiplier: Multiplier applied to the error when feet are too close
+            (distance < ref_distance). Makes the penalty asymmetrically steeper for
+            feet approaching each other. With L2 norm the effective penalty scales
+            by close_multiplier^2.
+        episode_delay_s: Seconds at episode start with zero penalty (recovery window).
+        episode_ramp_s: Seconds over which penalty linearly ramps from 0 to 1 after delay.
 
     Returns:
         Penalty tensor [num_envs] - higher when feet distance deviates from reference.
@@ -403,18 +617,18 @@ def feet_distance_from_ref(
         # If not exactly 2 feet specified, return zeros (no penalty)
         return torch.zeros(env.num_envs, device=env.device)
 
-    feet_pos_b = transform_to_asset_frame(feet_pos_w, asset)
+    if distance_mode == "absolute":
+        # Full 3D Euclidean distance in world frame — works regardless of body orientation
+        distance = torch.norm(feet_pos_w[:, 0] - feet_pos_w[:, 1], dim=-1)
+    else:
+        feet_pos_b = transform_to_asset_frame(feet_pos_w, asset)
+        left_foot_pos = feet_pos_b[:, 0]  # [num_envs, 3]
+        right_foot_pos = feet_pos_b[:, 1]  # [num_envs, 3]
+        # Lateral (Y-axis) distance in body frame
+        distance = torch.abs(left_foot_pos[:, 1] - right_foot_pos[:, 1])
 
-    # Get positions of left and right feet
-    left_foot_pos = feet_pos_b[:, 0]  # [num_envs, 3]
-    right_foot_pos = feet_pos_b[:, 1]  # [num_envs, 3]
-
-    # Calculate lateral (Y-axis) distance between feet
-    # In world frame, Y-axis typically represents lateral direction
-    lateral_distance = torch.abs(left_foot_pos[:, 1] - right_foot_pos[:, 1])
-
-    # Compute penalty as squared deviation from reference distance
-    distance_error = lateral_distance - ref_distance
+    # Compute deviation from reference distance
+    distance_error = distance - ref_distance
 
     if command_name is not None:
         command = env.command_manager.get_command(command_name)
@@ -422,12 +636,39 @@ def feet_distance_from_ref(
         large_lateral_velocity = lateral_velocity_command > lateral_velocity_threshold
         distance_error[large_lateral_velocity] = 0
 
+    # One-sided hard barrier: too close is penalized immediately,
+    # too far is tolerated up to error_threshold, then full error kicks in (discontinuous).
+    distance_error = torch.where(
+        distance_error > error_threshold,
+        distance_error,
+        torch.where(distance_error < 0, distance_error, torch.zeros_like(distance_error)),
+    )
+
+    # Asymmetric penalty: amplify error when feet are too close
+    if close_multiplier != 1.0:
+        distance_error = torch.where(
+            distance_error < 0,
+            distance_error * close_multiplier,
+            distance_error,
+        )
+
     if norm == "l1":
-        return torch.abs(distance_error)
+        penalty = torch.abs(distance_error)
     elif norm == "l2":
-        return torch.square(distance_error)
+        penalty = distance_error**2
     else:
         raise ValueError(f"Invalid norm: {norm}. Must be 'l1' or 'l2'.")
+
+    # Episode time gate: zero penalty during delay, linear ramp after
+    if episode_delay_s > 0 or episode_ramp_s > 0:
+        episode_time = env.episode_length_buf * env.step_dt
+        if episode_ramp_s > 0:
+            scale = torch.clamp((episode_time - episode_delay_s) / episode_ramp_s, 0.0, 1.0)
+        else:
+            scale = (episode_time >= episode_delay_s).float()
+        penalty = penalty * scale
+
+    return penalty
 
 
 def feet_distance_from_ref_if_standing(
@@ -438,10 +679,25 @@ def feet_distance_from_ref_if_standing(
     command_name: str | None = None,
     lateral_velocity_threshold: float = 0.5,
     sensor_cfg: SceneEntityCfg | None = None,
-    norm: Literal["l1", "l2"] = "l2",
+    norm: Literal["l1", "l2"] = "l1",
+    error_threshold: float = 0.0,
+    distance_mode: Literal["lateral", "absolute"] = "lateral",
+    close_multiplier: float = 1.0,
+    episode_delay_s: float = 0.0,
+    episode_ramp_s: float = 0.0,
 ) -> torch.Tensor:
     distance_error = feet_distance_from_ref(
-        env, asset_cfg, ref_distance, command_name, lateral_velocity_threshold, norm
+        env,
+        asset_cfg=asset_cfg,
+        ref_distance=ref_distance,
+        command_name=command_name,
+        lateral_velocity_threshold=lateral_velocity_threshold,
+        norm=norm,
+        error_threshold=error_threshold,
+        distance_mode=distance_mode,
+        close_multiplier=close_multiplier,
+        episode_delay_s=episode_delay_s,
+        episode_ramp_s=episode_ramp_s,
     )
     is_standing = if_standing(env, standing_height_threshold, asset_cfg, sensor_cfg)
     return distance_error * is_standing
@@ -464,16 +720,22 @@ def jumping(env: ManagerBasedRLEnv, threshold: float, sensor_cfg: SceneEntityCfg
     return is_jumping.float()
 
 
-def impact_velocity_l1(
-    env: ManagerBasedRLEnv, sensor_cfg: SceneEntityCfg, force_threshold: float = 10.0
+def impact_velocity(
+    env: ManagerBasedRLEnv,
+    sensor_cfg: SceneEntityCfg,
+    force_threshold: float = 10.0,
+    kernel: str = "l1",
 ) -> torch.Tensor:
     """Penalize large impact velocities.
 
+    Uses the velocity history buffer to robustly measure how fast a body was moving
+    when it made ground contact. The max velocity across the history window is used.
+
     Args:
         env: The environment.
-        force_threshold: The force threshold for the impact.
-        velocity_threshold: The velocity threshold for the impact.
-        sensor_cfg: The configuration for the foot contact sensor.
+        sensor_cfg: The configuration for the contact sensor.
+        force_threshold: The force threshold (N) to consider a body as "in contact".
+        kernel: Penalty kernel — "l1" (linear) or "l2" (squared, penalizes outliers more).
     """
     contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
     # compute the penalty
@@ -487,9 +749,12 @@ def impact_velocity_l1(
         dim=1,
     )[0]
 
-    impact_velocities = torch.where(in_contact, body_velocities, 0.0).sum(dim=1)
+    impact_velocities = torch.where(in_contact, body_velocities, 0.0)
 
-    return impact_velocities
+    if kernel == "l2":
+        impact_velocities = torch.square(impact_velocities)
+
+    return impact_velocities.sum(dim=1)
 
 
 def no_undersired_base_velocity_exp(
@@ -544,6 +809,69 @@ def equal_foot_force(env: ManagerBasedRLEnv, sensor_cfg: SceneEntityCfg) -> torc
     reward = 1.0 - torch.abs(mean_force.unsqueeze(1) - feet_z_forces).mean(dim=1) / (mean_force + 1e-6)
 
     return reward
+
+
+class ground_unloaded(ManagerTermBase):
+    """Penalty for not bearing weight on specified contact bodies. Returns 0-1.
+
+    0 when all weight is on the specified bodies, 1 when no ground contact.
+    Use with a negative weight to penalize jumping or lifting off the ground.
+    Can be used with feet only, or with additional bodies (knees, hands, etc.)
+    to also reward ground contact when the robot is down.
+    """
+
+    def __init__(self, cfg: RewardTermCfg, env: ManagerBasedRLEnv):
+        super().__init__(cfg, env)
+        asset: Articulation = env.scene[cfg.params["asset_cfg"].name]
+        gravity = abs(env.cfg.sim.gravity[2])
+        self._expected_weight = asset.data.default_mass.sum(dim=1).to(env.device) * gravity
+
+    def __call__(
+        self,
+        env: ManagerBasedRLEnv,
+        sensor_cfg: SceneEntityCfg,
+        asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),  # noqa: ARG002
+        command_name: str | None = None,
+    ) -> torch.Tensor:
+        contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+        feet_z_forces = contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, 2]
+        total_feet_force = feet_z_forces.sum(dim=1)
+        grounded_ratio = torch.clamp(total_feet_force / (self._expected_weight + 1e-6), 0.0, 1.0)
+        penalty = 1.0 - grounded_ratio
+        if command_name is not None:
+            command_term = env.command_manager.get_term(command_name)
+            penalty = penalty * (command_term.target_height >= 0).float()
+        return penalty
+
+
+def completely_airborne(
+    env: ManagerBasedRLEnv,
+    sensor_cfg: SceneEntityCfg,
+    threshold: float = 1.0,
+) -> torch.Tensor:
+    """Binary penalty when no body has ground contact at all.
+
+    Returns 1.0 when the robot is completely airborne (no body touching the ground),
+    0.0 otherwise. Use with a large negative weight to severely penalize jumping/flying.
+
+    Unlike ground_unloaded which only checks feet, this checks ALL specified bodies
+    (pass body_names=".*" to check everything). The robot can be lying down on its
+    knees/torso and won't be penalized — only fully airborne states are penalized.
+
+    Args:
+        env: The environment.
+        sensor_cfg: Contact sensor config with body_names specifying which bodies to check.
+        threshold: Minimum force magnitude (N) to consider a body as "in contact".
+    """
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    # net_forces_w shape: (num_envs, num_bodies, 3)
+    forces = contact_sensor.data.net_forces_w[:, sensor_cfg.body_ids, :]
+    # Force magnitude per body
+    force_magnitude = torch.norm(forces, dim=-1)  # (num_envs, num_bodies)
+    # Any body in contact?
+    any_contact = (force_magnitude > threshold).any(dim=-1)  # (num_envs,)
+    # Penalty = 1.0 when completely airborne, 0.0 when any body touches ground
+    return (~any_contact).float()
 
 
 def equal_foot_force_if_standing(
@@ -647,6 +975,68 @@ def moving(
     ang_vels = asset.data.body_ang_vel_w.norm(dim=-1)
 
     penalty = lin_vels.mean(dim=1) * weight_lin + ang_vels.mean(dim=1) * weight_ang
+    return penalty
+
+
+def moving_if_tracking(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg,
+    command_name: str,
+    error_threshold: float,
+    weight_lin: float = 1.0,
+    weight_ang: float = 1.0,
+) -> torch.Tensor:
+    """Penalize the agent for moving only when the height tracking error is below a threshold.
+
+    Once the robot has reached its commanded height (error < threshold), it should stay still.
+    While still moving toward the target, no penalty is applied.
+    """
+    command_term = env.command_manager.get_term(command_name)
+    error = torch.abs(command_term.measured_height - command_term.target_height)
+    is_tracking = (error < error_threshold).float()
+    penalty = moving(env, asset_cfg, weight_lin, weight_ang)
+    return penalty * is_tracking
+
+
+def relaxation_penalty(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    pos_weight: float = 1.0,
+    torque_weight: float = 0.001,
+) -> torch.Tensor:
+    """Penalty for not being relaxed when height command is negative.
+
+    Weighted sum of squared errors, gated on command < 0:
+        intensity * pos_weight * sum(deviation²) + is_negative * torque_weight * sum(torque²)
+
+    The position term is scaled by ``relaxation_intensity`` (0 at command=0,
+    1 at the most negative command) so the pressure to reach default joints
+    increases with more negative commands.  The torque term uses a binary gate
+    (always full when command < 0).
+
+    Use with a negative reward weight. Returns 0 when command is non-negative.
+
+    Args:
+        env: The environment.
+        command_name: Name of the height command term.
+        asset_cfg: Robot asset config (optionally with joint_names to restrict to specific joints).
+        pos_weight: Weight for joint position deviation from default.
+        torque_weight: Weight for joint torques.
+    """
+    command_term: SmoothHeightCommand = env.command_manager.get_term(command_name)
+    intensity = command_term.relaxation_intensity
+    is_relaxation = (command_term.target_height < 0).float()
+
+    asset: Articulation = env.scene[asset_cfg.name]
+
+    deviation = asset.data.joint_pos[:, asset_cfg.joint_ids] - asset.data.default_joint_pos[:, asset_cfg.joint_ids]
+    torques = asset.data.applied_torque[:, asset_cfg.joint_ids]
+
+    penalty = intensity * pos_weight * torch.sum(deviation**2, dim=1) + is_relaxation * torque_weight * torch.sum(
+        torques**2, dim=1
+    )
+
     return penalty
 
 
@@ -795,27 +1185,6 @@ def feet_slip(
     return reward
 
 
-def joint_deviation_if_standing(
-    env: ManagerBasedRLEnv,
-    standing_height_threshold: float,
-    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
-    sensor_cfg: SceneEntityCfg | None = None,
-    mode: Literal["l1", "l2"] = "l1",
-) -> torch.Tensor:
-    """Penalize joint positions that deviate from the default one."""
-    # extract the used quantities (to enable type-hinting)
-    asset: Articulation = env.scene[asset_cfg.name]
-    # compute out of limits constraints
-    angle = asset.data.joint_pos[:, asset_cfg.joint_ids] - asset.data.default_joint_pos[:, asset_cfg.joint_ids]
-    is_standing = if_standing(env, standing_height_threshold, asset_cfg, sensor_cfg)
-    if mode == "l1":
-        return torch.sum(torch.abs(angle), dim=1) * is_standing
-    elif mode == "l2":
-        return torch.sum(torch.square(angle), dim=1) * is_standing
-    else:
-        raise ValueError(f"Invalid mode: {mode}. Must be 'l1' or 'l2'.")
-
-
 def joint_deviation_exp_if_standing(
     env: ManagerBasedRLEnv,
     standing_height_threshold: float,
@@ -830,3 +1199,46 @@ def joint_deviation_exp_if_standing(
     angle = asset.data.joint_pos[:, asset_cfg.joint_ids] - asset.data.default_joint_pos[:, asset_cfg.joint_ids]
     is_standing = if_standing(env, standing_height_threshold, asset_cfg, sensor_cfg)
     return torch.sum(torch.exp(-torch.square(angle) / std**2), dim=1) * is_standing
+
+
+def feet_air_time_positive_biped_command(
+    env: ManagerBasedRLEnv, command_name: str, command_slice: slice, threshold: float, sensor_cfg: SceneEntityCfg
+) -> torch.Tensor:
+    """Reward long steps taken by the feet for bipeds.
+
+    This function rewards the agent for taking steps up to a specified threshold and also keep one foot at
+    a time in the air.
+
+    If the commands are small (i.e. the agent is not supposed to take a step), then the reward is zero.
+    """
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+    # compute the reward
+    air_time = contact_sensor.data.current_air_time[:, sensor_cfg.body_ids]
+    contact_time = contact_sensor.data.current_contact_time[:, sensor_cfg.body_ids]
+    in_contact = contact_time > 0.0
+    in_mode_time = torch.where(in_contact, contact_time, air_time)
+    single_stance = torch.sum(in_contact.int(), dim=1) == 1
+    reward = torch.min(torch.where(single_stance.unsqueeze(-1), in_mode_time, 0.0), dim=1)[0]
+    reward = torch.clamp(reward, max=threshold)
+    # no reward for zero command
+    reward *= torch.norm(env.command_manager.get_command(command_name)[:, command_slice], dim=1) > 0.1
+    return reward
+
+
+def joint_deviation_if_standing(
+    env: ManagerBasedRLEnv,
+    standing_height_threshold: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    sensor_cfg: SceneEntityCfg | None = None,
+    mode: Literal["l1", "l2"] = "l1",
+) -> torch.Tensor:
+    """Penalize joint positions that deviate from the default one, gated by standing."""
+    asset: Articulation = env.scene[asset_cfg.name]
+    angle = asset.data.joint_pos[:, asset_cfg.joint_ids] - asset.data.default_joint_pos[:, asset_cfg.joint_ids]
+    is_standing = if_standing(env, standing_height_threshold, asset_cfg, sensor_cfg)
+    if mode == "l1":
+        return torch.sum(torch.abs(angle), dim=1) * is_standing
+    elif mode == "l2":
+        return torch.sum(torch.square(angle), dim=1) * is_standing
+    else:
+        raise ValueError(f"Invalid mode: {mode}. Must be 'l1' or 'l2'.")

--- a/agile/rl_env/mdp/rewards/regularization_rewards.py
+++ b/agile/rl_env/mdp/rewards/regularization_rewards.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 
 import torch
 
+from isaaclab.assets import Articulation
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.envs.mdp.rewards import action_l2
 from isaaclab.managers import ManagerTermBase, SceneEntityCfg
@@ -124,6 +125,23 @@ def action_rate_l2(env: ManagerBasedRLEnv, asset_cfg: SceneEntityCfg = SceneEnti
     )
 
 
+def joint_pos_tracking_error_l2(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    action_name: str = "joint_pos",
+) -> torch.Tensor:
+    """Penalize deviation between PD target and actual joint positions.
+
+    Discourages commanding joint targets far from the current position,
+    which produces high torques and jerky motion.
+    """
+    robot: Articulation = env.scene[asset_cfg.name]
+    action_term = env.action_manager._terms[action_name]
+    target = action_term.processed_actions  # (num_envs, num_joints) — the actual PD position target
+    current = robot.data.joint_pos[:, action_term._joint_ids]
+    return torch.sum(torch.square(target - current), dim=1)
+
+
 def action_rate_l2_if_actor_active(
     env: ManagerBasedRLEnv, rest_duration_s: float, asset_cfg: SceneEntityCfg = SceneEntityCfg("robot")
 ) -> torch.Tensor:
@@ -140,6 +158,18 @@ def action_l2_if_actor_active(env: ManagerBasedRLEnv, rest_duration_s: float) ->
     env_in_rest_phase = env.episode_length_buf < int(rest_duration_s / env.step_dt)
     action[env_in_rest_phase] = 0
     return action
+
+
+def joint_deviation_l1(
+    env: ManagerBasedRLEnv,
+    robot_cfg: SceneEntityCfg | None = None,
+) -> torch.Tensor:
+    """Reward for penalizing joint deviation from default angles (L1 norm)."""
+    robot, robot_cfg = get_robot_cfg(env, robot_cfg)
+    return torch.sum(
+        torch.abs(robot.data.joint_pos[:, robot_cfg.joint_ids] - robot.data.default_joint_pos[:, robot_cfg.joint_ids]),
+        dim=1,
+    )
 
 
 def joint_deviation_l2(

--- a/agile/rl_env/mdp/rewards/task_rewards.py
+++ b/agile/rl_env/mdp/rewards/task_rewards.py
@@ -13,65 +13,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import torch
 
-from isaaclab.assets import RigidObject
+from isaaclab.assets import Articulation, RigidObject
 from isaaclab.envs import ManagerBasedRLEnv
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.sensors import RayCaster
 from isaaclab.utils.math import quat_apply_inverse, yaw_quat
 
-from agile.rl_env.mdp.commands import UniformVelocityBaseHeightCommand
+from agile.rl_env.mdp.commands import (
+    UniformVelocityBaseHeightCommand,
+)
 from agile.rl_env.mdp.utils import get_contact_sensor_cfg, get_robot_cfg
 
 
-def nominal_posture_at_end_exp(
+def standing_at_timeout(
     env: ManagerBasedRLEnv,
-    command_name: str,
-    std: float,
-    progress_threshold: float = 0.8,
+    min_height: float,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    sensor_cfg: SceneEntityCfg | None = None,
 ) -> torch.Tensor:
-    """Reward the robot for reaching the final frame's joint posture at the end of trajectory.
+    """Reward for being at standing height when the episode times out.
 
-    This reward encourages the robot to match the joint positions from the last frame
-    of the reference trajectory. The reward is gated by trajectory progress and uses
-    an exponential kernel on the deviation from the target final pose.
+    This reward gives a bonus when the episode ends due to timeout AND the robot
+    is currently standing at or above the minimum height. This encourages:
+    1. Standing up
+    2. Staying standing for the entire episode duration
 
     Args:
         env: The environment.
-        command_name: Name of the tracking command term.
-        std: Standard deviation for exponential kernel on joint position deviation.
-        progress_threshold: Trajectory progress above which to start rewarding target posture.
-            Default 0.8 = last 20% of trajectory.
+        min_height: Minimum height to be considered standing.
+        asset_cfg: Asset configuration for the robot.
+        sensor_cfg: Optional height sensor for rough terrain adjustment.
 
     Returns:
-        Reward tensor: exp kernel on joint deviation from final frame target, gated by progress.
+        1.0 if timeout AND standing, 0.0 otherwise.
     """
-    command = env.command_manager.get_term(command_name)
-    robot = env.scene[command.cfg.asset_name]
+    # Check if this is a timeout termination
+    is_timeout = env.termination_manager.time_outs
 
-    # Compute trajectory progress [0, 1]
-    progress = command.timestep_counter.float() / max(command.num_timesteps - 1, 1)
-    progress = torch.clamp(progress, 0.0, 1.0)
+    # Get current height
+    asset: RigidObject = env.scene[asset_cfg.name]
+    if sensor_cfg is not None:
+        sensor: RayCaster = env.scene[sensor_cfg.name]
+        current_height = asset.data.root_pos_w[:, 2] - torch.mean(sensor.data.ray_hits_w[..., 2], dim=1)
+    else:
+        current_height = asset.data.root_pos_w[:, 2]
 
-    # Compute progress-based gate: ramps from 0 at threshold to 1 at progress=1.0
-    gate = (progress - progress_threshold) / (1.0 - progress_threshold)
-    gate = torch.clamp(gate, 0.0, 1.0)
+    is_standing = current_height > min_height
 
-    # Get target joint positions from the last frame of the reference trajectory
-    # Shape: (num_tracked_joints,)
-    target_pos = command.target_tracked_joint_pos[-1]
-
-    # Get robot's current joint positions for the tracked joints
-    # Shape: (num_envs, num_tracked_joints)
-    current_pos = robot.data.joint_pos[:, command.tracked_joint_ids]
-
-    # Compute deviation from target posture
-    deviation_sq = torch.sum(torch.square(current_pos - target_pos), dim=-1)
-    posture_reward = torch.exp(-deviation_sq / (std**2))
-
-    # Apply progress-based gate
-    return posture_reward * gate
+    # Reward only when timeout AND standing
+    return (is_timeout & is_standing).float()
 
 
 def static_at_goal_exp(
@@ -145,12 +138,251 @@ def static_at_goal_exp(
     return static_reward * gate
 
 
+def _at_goal_gate(env: ManagerBasedRLEnv, command_name: str, position_threshold: float) -> torch.Tensor:
+    """Return a float mask that is 1.0 for envs that are standing or near the goal."""
+    command_term = env.command_manager.get_term(command_name)
+    is_standing = command_term.is_standing_env
+    pos_error = command_term.metrics.get("torso_position_error", None)
+    if pos_error is not None:
+        return (is_standing | (pos_error < position_threshold)).float()
+    return is_standing.float()
+
+
+def stand_still_reward(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    std_lin: float = 0.15,
+    std_ang: float = 0.5,
+    std_dist: float = 0.5,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Reward for standing still near the goal, using a product of three gaussians.
+
+    The reward is ``exp(-lin²/std_lin²) * exp(-ang²/std_ang²) * exp(-dist²/std_dist²)``,
+    providing smooth gradient everywhere. Standing envs get dist_gate = 1.0.
+
+    Use with a positive weight.
+    """
+    robot: Articulation = env.scene[asset_cfg.name]
+    command_term = env.command_manager.get_term(command_name)
+
+    # Linear velocity gaussian
+    lin_vel_sq = torch.sum(torch.square(robot.data.root_lin_vel_b), dim=-1)
+    lin_reward = torch.exp(-lin_vel_sq / (std_lin * std_lin))
+
+    # Angular velocity gaussian
+    ang_vel_sq = torch.sum(torch.square(robot.data.root_ang_vel_b), dim=-1)
+    ang_reward = torch.exp(-ang_vel_sq / (std_ang * std_ang))
+
+    # Distance gaussian (smooth gate)
+    pos_error = command_term.metrics.get("torso_position_error", None)
+    if pos_error is not None:
+        dist_gate = torch.where(
+            command_term.is_standing_env,
+            torch.ones_like(pos_error),
+            torch.exp(-torch.square(pos_error) / (std_dist * std_dist)),
+        )
+    else:
+        dist_gate = command_term.is_standing_env.float()
+
+    return lin_reward * ang_reward * dist_gate
+
+
+def feet_posture_at_goal(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    position_threshold: float = 0.1,
+    feet_asset_cfg: SceneEntityCfg = SceneEntityCfg("robot", body_names=".*ankle_roll_link"),
+    base_body_cfg: SceneEntityCfg = SceneEntityCfg("robot", body_names="pelvis"),
+) -> torch.Tensor:
+    """Penalize feet yaw deviation from pelvis when at the goal or standing still.
+
+    Use with a negative weight.
+    """
+    from agile.rl_env.mdp.rewards.aestetic_rewards import feet_yaw_mean_vs_base
+
+    gate = _at_goal_gate(env, command_name, position_threshold)
+    return feet_yaw_mean_vs_base(env, feet_asset_cfg, base_body_cfg) * gate
+
+
+def feet_distance_at_goal(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    position_threshold: float = 0.1,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+    ref_distance: float = 0.2,
+) -> torch.Tensor:
+    """Penalize feet distance deviation from reference when at the goal or standing still.
+
+    Use with a negative weight.
+    """
+    from agile.rl_env.mdp.rewards.aestetic_rewards import feet_distance_from_ref
+
+    gate = _at_goal_gate(env, command_name, position_threshold)
+    return feet_distance_from_ref(env, asset_cfg=asset_cfg, ref_distance=ref_distance, norm="l2") * gate
+
+
+def feet_touching_penalty(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot", body_names=".*ankle_roll_link"),
+    min_distance: float = 0.1,
+) -> torch.Tensor:
+    """Binary penalty when feet are closer than *min_distance*.
+
+    Returns 1.0 when feet are touching (distance < min_distance), 0.0 otherwise.
+    Use with a negative weight.
+    """
+    robot: Articulation = env.scene[asset_cfg.name]
+    feet_pos = robot.data.body_pos_w[:, asset_cfg.body_ids]
+    distance = torch.norm(feet_pos[:, 0] - feet_pos[:, 1], dim=1)
+    return (distance < min_distance).float()
+
+
+def nominal_posture_at_end_exp(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    std: float,
+    progress_threshold: float = 0.8,
+) -> torch.Tensor:
+    """Reward the robot for reaching the final frame's joint posture at the end of trajectory.
+
+    This reward encourages the robot to match the joint positions from the last frame
+    of the reference trajectory. The reward is gated by trajectory progress and uses
+    an exponential kernel on the deviation from the target final pose.
+
+    Args:
+        env: The environment.
+        command_name: Name of the tracking command term.
+        std: Standard deviation for exponential kernel on joint position deviation.
+        progress_threshold: Trajectory progress above which to start rewarding target posture.
+            Default 0.8 = last 20% of trajectory.
+
+    Returns:
+        Reward tensor: exp kernel on joint deviation from final frame target, gated by progress.
+    """
+    command = env.command_manager.get_term(command_name)
+    robot = env.scene[command.cfg.asset_name]
+
+    # Compute trajectory progress [0, 1]
+    progress = command.timestep_counter.float() / max(command.num_timesteps - 1, 1)
+    progress = torch.clamp(progress, 0.0, 1.0)
+
+    # Compute progress-based gate: ramps from 0 at threshold to 1 at progress=1.0
+    gate = (progress - progress_threshold) / (1.0 - progress_threshold)
+    gate = torch.clamp(gate, 0.0, 1.0)
+
+    # Get target joint positions from the last frame of the reference trajectory
+    # Shape: (num_tracked_joints,)
+    target_pos = command.target_tracked_joint_pos[-1]
+
+    # Get robot's current joint positions for the tracked joints
+    # Shape: (num_envs, num_tracked_joints)
+    current_pos = robot.data.joint_pos[:, command.tracked_joint_ids]
+
+    # Compute deviation from target posture
+    deviation_sq = torch.sum(torch.square(current_pos - target_pos), dim=-1)
+    posture_reward = torch.exp(-deviation_sq / (std**2))
+
+    # Apply progress-based gate
+    return posture_reward * gate
+
+
 # Note: The command gets updated after the reward is computed resulting in a one-step reward delay.
 def track_base_height_exp_smooth(env: ManagerBasedRLEnv, command_name: str, std: float) -> torch.Tensor:
     """Reward the agent for tracking the base height."""
     command_term: UniformVelocityBaseHeightCommand = env.command_manager.get_term(command_name)
     base_height_error = torch.square(command_term.base_height - command_term.target_height)
     return torch.exp(-base_height_error / std**2)
+
+
+def track_lin_vel_xy_yaw_frame_exp_weighted_simplified(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    std: float = 0.2,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Reward tracking of linear velocity commands (xy axes) in the gravity aligned robot frame using exponential kernel.
+
+    The tracking error is additionally weighted by the command velocity's magnitude. Higher commanded velocities
+    receive higher weight, encouraging accurate tracking especially at higher speeds.
+    """
+
+    # extract the used quantities (to enable type-hinting)
+    asset = env.scene[asset_cfg.name]
+    vel_yaw = quat_apply_inverse(yaw_quat(asset.data.root_quat_w), asset.data.root_lin_vel_w[:, :3])
+    command_term = env.command_manager.get_term(command_name)
+    vel_cmd = command_term.vel_command_b[:, :2]
+
+    # Compute tracking error
+    lin_vel_error = torch.sum(torch.square(vel_cmd - vel_yaw[:, :2]), dim=1)
+
+    # Compute adaptive std based on commanded velocity magnitude
+    cmd_vel_magnitude = torch.norm(vel_cmd, dim=1)
+    # Define velocity bounds for scaling (assuming min=0.01
+    vel_min = command_term.cfg.min_vel_norm
+    vel_max = torch.norm(torch.tensor([command_term.cfg.ranges.lin_vel_x[1], command_term.cfg.ranges.lin_vel_y[1]]))
+
+    # Clamp magnitude to expected range
+    cmd_vel_magnitude_clamped = torch.clamp(cmd_vel_magnitude, vel_min, vel_max)
+
+    # Map direct relationship to weight range
+    # Using linear interpolation: higher commanded velocity -> higher weight
+    weight_min = 1.0
+    weight_max = 2.0
+
+    # Normalized direct mapping: high velocity -> high weight, low velocity -> low weight
+    normalized = (cmd_vel_magnitude_clamped - vel_min) / (vel_max - vel_min)
+    weight = weight_min + (weight_max - weight_min) * normalized
+
+    # Return weighted exponential reward
+    return weight * torch.exp(-lin_vel_error / std**2)
+
+
+def track_ang_vel_z_world_exp_weighted_simplified(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    std: float = 0.2,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),
+) -> torch.Tensor:
+    """Reward tracking of angular velocity commands (yaw) in world frame using exponential kernel with magnitude-based weighting.
+
+    The tracking error is additionally weighted by the command angular velocity's magnitude. Higher commanded angular
+    velocities receive higher weight, encouraging accurate tracking especially at higher rotation speeds.
+
+    This is similar to track_lin_vel_xy_yaw_frame_exp_weighted_simplified but for angular velocity.
+    """
+    # Extract the used quantities
+    asset = env.scene[asset_cfg.name]
+    command_term = env.command_manager.get_term(command_name)
+
+    # Get commanded and actual angular velocities
+    ang_vel_cmd = command_term.vel_command_b[:, 2]  # commanded angular velocity z
+    ang_vel_actual = asset.data.root_ang_vel_w[:, 2]  # actual angular velocity z
+
+    # Compute tracking error
+    ang_vel_error = torch.square(ang_vel_cmd - ang_vel_actual)
+
+    # Compute weight based on commanded angular velocity magnitude
+    cmd_ang_vel_magnitude = torch.abs(ang_vel_cmd)
+
+    # Define angular velocity bounds for scaling
+    ang_vel_min = command_term.cfg.min_vel_norm  # minimum angular velocity for scaling
+    ang_vel_max = abs(command_term.cfg.ranges.ang_vel_z[1])  # max from config
+
+    # Clamp magnitude to expected range
+    cmd_ang_vel_magnitude_clamped = torch.clamp(cmd_ang_vel_magnitude, ang_vel_min, ang_vel_max)
+
+    # Map direct relationship to weight range
+    # Using linear interpolation: higher commanded angular velocity -> higher weight
+    weight_min = 1.0
+    weight_max = 2.0
+
+    # Normalized direct mapping: high angular velocity -> high weight, low angular velocity -> low weight
+    normalized = (cmd_ang_vel_magnitude_clamped - ang_vel_min) / (ang_vel_max - ang_vel_min)
+    weight = weight_min + (weight_max - weight_min) * normalized
+
+    # Return weighted exponential reward
+    return weight * torch.exp(-ang_vel_error / std**2)
 
 
 def track_lin_vel_xy_yaw_frame_exp_weighted(
@@ -295,6 +527,34 @@ def base_height_exp(
         adjusted_target_height = target_height
     height_error = torch.square(asset.data.root_pos_w[:, 2] - adjusted_target_height)
     return torch.exp(-height_error / std**2)
+
+
+def track_height_command_exp(
+    env: ManagerBasedRLEnv,
+    command_name: str,
+    std: float,
+    settle_gate: bool = False,
+) -> torch.Tensor:
+    """Reward for tracking a height command with exponential kernel.
+
+    Uses the command term's measured_height and target_height properties.
+    Works with SmoothHeightCommand or any command term that exposes these.
+
+    Args:
+        env: The environment.
+        command_name: Name of the height command term.
+        std: Standard deviation for the exponential kernel.
+        settle_gate: If True, only give reward when the command has settled
+            (enough time since last resample) AND the command is non-negative.
+            Requires the command term to expose a ``settled`` property.
+    """
+    command_term = env.command_manager.get_term(command_name)
+    height_error = torch.square(command_term.measured_height - command_term.target_height)
+    reward = torch.exp(-height_error / std**2)
+    if settle_gate:
+        active = command_term.settled & (command_term.target_height >= 0)
+        reward = reward * active.float()
+    return reward
 
 
 def base_height_in_threshold(env: ManagerBasedRLEnv, command_name: str, threshold: float) -> torch.Tensor:

--- a/agile/rl_env/mdp/symmetry/symmetry_g1.py
+++ b/agile/rl_env/mdp/symmetry/symmetry_g1.py
@@ -110,6 +110,34 @@ def mirror_joints_G1(actions: torch.Tensor, env: ManagerBasedRLEnv) -> torch.Ten
     return mirrored_actions
 
 
+def mirror_bodies_G1(bodies: torch.Tensor, env: ManagerBasedRLEnv) -> torch.Tensor:
+    """Left-right mirroring of all robot bodies."""
+    mirrored_indices = resolve_body_names_g1(tuple(env.unwrapped.scene.articulations["robot"].body_names))
+    mirrored_bodies = bodies.clone()
+    mirrored_bodies[..., mirrored_indices] = bodies
+    return mirrored_bodies
+
+
+@lru_cache(maxsize=10)
+def resolve_body_names_g1(body_names: tuple[str, ...]) -> list[int]:
+    """Resolve body names to mirrored body indices."""
+    mirrored_indices = []
+    for source_body_name in body_names:
+        if "left" in source_body_name:
+            mirrored_body_name = source_body_name.replace("left", "right")
+        elif "right" in source_body_name:
+            mirrored_body_name = source_body_name.replace("right", "left")
+        else:
+            mirrored_body_name = source_body_name
+
+        if mirrored_body_name not in body_names:
+            raise ValueError(f"Mirrored body name {mirrored_body_name} not found in body names")
+
+        mirrored_indices.append(body_names.index(mirrored_body_name))
+
+    return mirrored_indices
+
+
 @lru_cache(maxsize=10)
 def resolve_joint_names_g1(action_joint_names: tuple[str, ...]) -> tuple[list[int], list[int]]:
     """Resolve the joint names to indices.
@@ -189,11 +217,13 @@ OBS_TO_MIRROR: dict[str, Callable] = {
     "controlled_joint_vel": mirror_actions_G1,
     "velocity_commands": mirror_velocity_commands,
     "velocity_height_commands": mirror_velocity_commands,
+    "height_command": identity,
     "height_commands": identity,
     "gait_cycle_commands": mirror_gait_cycle_commands,
     "height_scan": mirror_height_scan_left_right,
     "height_scan_feet": mirror_height_scan_feet_left_right,
     "base_height": identity,
+    "contact_forces": mirror_bodies_G1,
     "external_force_torque": mirror_external_force_torque,
     "base_com": mirror_base_com,
     "actuator_gains": mirror_actuator_gains,

--- a/agile/rl_env/mdp/terminations.py
+++ b/agile/rl_env/mdp/terminations.py
@@ -26,6 +26,59 @@ from isaaclab.utils.math import subtract_frame_transforms
 from agile.rl_env.mdp.utils import get_robot_cfg
 
 
+def ground_slam(
+    env: ManagerBasedRLEnv,
+    sensor_cfg: SceneEntityCfg,
+    velocity_threshold: float = 2.0,
+    force_threshold: float = 10.0,
+    prerequisite_curriculum: str | None = None,
+    prerequisite_threshold: float = 0.01,
+    prerequisite_direction: str = "below",
+) -> torch.Tensor:
+    """Terminate if any monitored body slams the ground with high impact velocity.
+
+    Uses the contact sensor's velocity history buffer to detect impact velocity at contact onset.
+    Only activates after an optional prerequisite curriculum reaches a threshold, so it doesn't
+    interfere with early training (e.g., while the robot is still learning to stand up).
+
+    Args:
+        env: The environment instance.
+        sensor_cfg: Contact sensor config with body_names specifying which bodies to monitor.
+        velocity_threshold: Maximum allowed impact velocity (m/s).
+        force_threshold: Minimum contact force (N) to consider a body as "in contact".
+        prerequisite_curriculum: If set, termination is only active when this curriculum
+            value crosses the threshold (e.g., "adaptive_lift" must reach ~0 before enabling).
+        prerequisite_threshold: Threshold value for the prerequisite curriculum.
+        prerequisite_direction: "below" = active when curriculum < threshold,
+            "above" = active when curriculum > threshold.
+    """
+    # Check prerequisite curriculum gate
+    if prerequisite_curriculum is not None:
+        prereq_value = env.curriculum_manager._curriculum_state.get(prerequisite_curriculum)
+        if prereq_value is None:
+            return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+        if prerequisite_direction == "below" and prereq_value >= prerequisite_threshold:
+            return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+        if prerequisite_direction == "above" and prereq_value < prerequisite_threshold:
+            return torch.zeros(env.num_envs, dtype=torch.bool, device=env.device)
+
+    contact_sensor: ContactSensor = env.scene.sensors[sensor_cfg.name]
+
+    net_contact_forces = contact_sensor.data.net_forces_w_history
+    in_contact = (
+        torch.max(torch.norm(net_contact_forces[:, :, sensor_cfg.body_ids], dim=-1), dim=1)[0] > force_threshold
+    )
+
+    body_velocities = torch.max(
+        torch.norm(contact_sensor.data.velocities_w_history[:, :, sensor_cfg.body_ids], dim=-1),
+        dim=1,
+    )[0]
+
+    # Terminate if ANY monitored body is in contact AND exceeds velocity threshold
+    slam_detected = in_contact & (body_velocities > velocity_threshold)
+    return torch.any(slam_detected, dim=1)
+
+
 def illegal_ground_contact(
     env: ManagerBasedRLEnv,
     threshold: float,
@@ -233,6 +286,50 @@ def link_distance(
     return too_close
 
 
+def illegal_link_distance_lateral(
+    env: ManagerBasedRLEnv,
+    min_distance_threshold: float = 0.05,
+    max_distance_threshold: float | None = None,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),  # noqa: B008
+) -> torch.Tensor:
+    """Terminate if the lateral (Y-axis in root frame) distance between two links is outside range.
+
+    Projects the link positions into the root body frame and checks the Y-axis separation.
+    This allows large forward/backward steps while constraining lateral splay.
+
+    Args:
+        env: Environment instance
+        min_distance_threshold: Minimum lateral distance. Terminate if closer than this.
+        max_distance_threshold: Maximum lateral distance. Terminate if farther than this. None to disable.
+        asset_cfg: Asset configuration (must specify exactly 2 links)
+
+    Returns:
+        Boolean tensor indicating which environments should terminate
+    """
+    robot, _ = get_robot_cfg(env, asset_cfg)
+    link_pos_w = robot.data.body_pos_w[:, asset_cfg.body_ids]
+
+    if len(asset_cfg.body_ids) != 2:
+        raise ValueError("Link distance is only supported for 2 links")
+
+    # Transform link positions into root frame
+    root_pos = robot.data.root_pos_w
+    root_quat = robot.data.root_quat_w
+    link0_b, _ = subtract_frame_transforms(root_pos, root_quat, link_pos_w[:, 0])
+    link1_b, _ = subtract_frame_transforms(root_pos, root_quat, link_pos_w[:, 1])
+
+    # Lateral distance = Y-axis separation in root frame
+    lateral_dist = torch.abs(link0_b[:, 1] - link1_b[:, 1])
+
+    too_close = lateral_dist < min_distance_threshold
+
+    if max_distance_threshold is not None:
+        too_far = lateral_dist > max_distance_threshold
+        return too_close | too_far
+
+    return too_close
+
+
 class standing(ManagerTermBase):
     def __init__(self, cfg: EventTermCfg, env: ManagerBasedRLEnv):
         super().__init__(cfg, env)
@@ -373,6 +470,61 @@ def bad_motion_body_pos_z_only(
     body_indices = _get_body_indices(command, body_names)
     error = torch.abs(command.body_pos_relative_w[:, body_indices, -1] - command.robot_body_pos_w[:, body_indices, -1])
     return torch.any(error > threshold, dim=-1)
+
+
+def invalid_state(
+    env: ManagerBasedRLEnv,
+    asset_cfg: SceneEntityCfg = SceneEntityCfg("robot"),  # noqa: B008
+    max_joint_vel: float = 100.0,
+    max_root_height: float = 10.0,
+    max_root_xy_distance: float = 200.0,
+    max_lin_vel: float = 50.0,
+    max_ang_vel: float = 100.0,
+) -> torch.Tensor:
+    """Terminate when physics values explode (NaN or exceeding thresholds).
+
+    This termination detects simulation instabilities before they cause NaN propagation.
+    It checks for NaN states, joint velocities, root position, and root velocities.
+
+    Args:
+        env: The environment instance.
+        asset_cfg: Configuration for the robot asset.
+        max_joint_vel: Maximum allowed joint velocity magnitude (rad/s). Default: 100.0
+        max_root_height: Maximum allowed root height above env origin (m). Default: 10.0
+        max_root_xy_distance: Maximum allowed XY distance from env origin (m). Default: 50.0
+        max_lin_vel: Maximum allowed linear velocity magnitude (m/s). Default: 50.0
+        max_ang_vel: Maximum allowed angular velocity magnitude (rad/s). Default: 100.0
+
+    Returns:
+        Boolean tensor indicating which environments have invalid states.
+    """
+    robot: Articulation = env.scene[asset_cfg.name]
+
+    # Check for NaN in any state
+    has_nan = (
+        torch.isnan(robot.data.joint_pos).any(dim=-1)
+        | torch.isnan(robot.data.joint_vel).any(dim=-1)
+        | torch.isnan(robot.data.root_pos_w).any(dim=-1)
+        | torch.isnan(robot.data.root_lin_vel_w).any(dim=-1)
+        | torch.isnan(robot.data.root_ang_vel_w).any(dim=-1)
+    )
+
+    # Check joint velocities
+    joint_vel_exceeded = torch.abs(robot.data.joint_vel).max(dim=-1).values > max_joint_vel
+
+    # Check root position (relative to env origin)
+    root_pos_rel = robot.data.root_pos_w - env.scene.env_origins
+    root_height_exceeded = root_pos_rel[:, 2] > max_root_height
+    root_xy_exceeded = torch.norm(root_pos_rel[:, :2], dim=-1) > max_root_xy_distance
+
+    # Check linear velocity
+    lin_vel_exceeded = torch.norm(robot.data.root_lin_vel_w, dim=-1) > max_lin_vel
+
+    # Check angular velocity
+    ang_vel_exceeded = torch.norm(robot.data.root_ang_vel_w, dim=-1) > max_ang_vel
+
+    # Combine all checks
+    return has_nan | joint_vel_exceeded | root_height_exceeded | root_xy_exceeded | lin_vel_exceeded | ang_vel_exceeded
 
 
 def out_of_bound(

--- a/agile/rl_env/mdp/terrains/terrains.py
+++ b/agile/rl_env/mdp/terrains/terrains.py
@@ -154,3 +154,33 @@ STAND_UP_ROUGH_TERRAIN_CFG = TerrainGeneratorCfg(
         "wave_small": terrain_gen.HfWaveTerrainCfg(proportion=0.3, amplitude_range=(0.01, 0.15), num_waves=3),
     },
 )
+
+
+STAND_UP_ROUGH_TERRAIN_G1_CFG = TerrainGeneratorCfg(
+    seed=42,  # Fixed seed for deterministic terrain generation (enables caching)
+    size=(8.0, 8.0),
+    border_width=100.0,
+    num_rows=8,  # num different difficulties
+    num_cols=9,  # num terrains per same difficulty level
+    horizontal_scale=0.1,
+    vertical_scale=0.01,
+    slope_threshold=0.9,
+    use_cache=False,
+    sub_terrains={
+        "boxes": terrain_gen.MeshRandomGridTerrainCfg(
+            proportion=0.2,
+            grid_width=0.45,
+            grid_height_range=(0.01, 0.075),
+            platform_width=0.1,
+        ),
+        "random_rough_small": HfRandomUniformTerrainDifficultyCfg(
+            proportion=0.2,
+            noise_range=(0.01, 0.1),
+            noise_step=0.01,
+            border_width=0.4,
+        ),
+        "wave_small": terrain_gen.HfWaveTerrainCfg(
+            proportion=0.2, amplitude_range=(0.01, 0.15), num_waves=4, border_width=0.2
+        ),
+    },
+)

--- a/agile/rl_env/tasks/stand_up/__init__.py
+++ b/agile/rl_env/tasks/stand_up/__init__.py
@@ -1,1 +1,4 @@
-from . import t1  # noqa: F401, F403
+from . import (
+    g1,  # noqa: F401, F403
+    t1,  # noqa: F401, F403
+)

--- a/agile/rl_env/tasks/stand_up/g1/__init__.py
+++ b/agile/rl_env/tasks/stand_up/g1/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gymnasium as gym
+
+from . import agents
+
+###########
+# RL envs #
+###########
+
+gym.register(
+    id="HeightTracking-G1-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.height_tracking_env_cfg:G1HeightTrackingEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:G1HeightTrackingPpoRunnerCfg",
+        "pre_learn_entry_point": f"{__name__}.pre_learn:pre_learn",
+    },
+)

--- a/agile/rl_env/tasks/stand_up/g1/agents/__init__.py
+++ b/agile/rl_env/tasks/stand_up/g1/agents/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/agile/rl_env/tasks/stand_up/g1/agents/rsl_rl_ppo_cfg.py
+++ b/agile/rl_env/tasks/stand_up/g1/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from isaaclab.utils import configclass
+
+from agile.rl_env.mdp.events import FallenStateDatasetCfg
+from agile.rl_env.mdp.symmetry import lr_mirror_G1  # noqa: F401
+from agile.rl_env.rsl_rl import (  # noqa: F401
+    RslRlL2C2Cfg,
+    RslRlOnPolicyRunnerCfg,
+    RslRlPpoActorCriticCfg,
+    RslRlPpoAlgorithmCfg,
+    RslRlRewardNormalizationCfg,
+    RslRlSymmetryCfg,
+)
+
+
+@configclass
+class G1HeightTrackingPpoRunnerCfg(RslRlOnPolicyRunnerCfg):
+    seed = 42
+    num_steps_per_env = 24
+    max_iterations = 100_000
+    save_interval = 250
+    experiment_name = "height_tracking_g1"
+    run_name = "height_tracking_g1"
+    wandb_project = "HeightTracking-G1"
+    empirical_normalization = False
+    enable_entropy_coef_annealing = False
+    entropy_coef_annealing_start_progress = 0.2
+    enable_entropy_coef_annealing_success_rate = 0.9
+    fallen_state_dataset_cfg: FallenStateDatasetCfg | None = FallenStateDatasetCfg(
+        spawn_orientation="on_back",
+        spawn_pitch_range=(-1.7, -1.4),
+        spawn_joint_mode="default",
+        initial_lin_vel_range=0.0,
+        initial_ang_vel_range=0.0,
+    )
+    fallen_state_dataset_secondary_cfg: FallenStateDatasetCfg | None = FallenStateDatasetCfg(
+        spawn_orientation="random",
+        spawn_joint_mode="random",
+        initial_lin_vel_range=1.0,
+        initial_ang_vel_range=1.0,
+    )
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[256, 256, 128],
+        critic_hidden_dims=[512, 256, 128],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.0025,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.995,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+        symmetry_cfg=RslRlSymmetryCfg(
+            use_data_augmentation=True,
+            use_mirror_loss=False,
+            data_augmentation_func=lr_mirror_G1,
+        ),
+        l2c2_cfg=RslRlL2C2Cfg(
+            lambda_actor=1.0,
+            lambda_critic=0.1,
+        ),
+        reward_normalization_cfg=RslRlRewardNormalizationCfg(
+            decay=0.999,  # ~693 steps half-life
+            epsilon=1e-2,
+            return_scale_decay=0.999,
+        ),
+    )

--- a/agile/rl_env/tasks/stand_up/g1/height_tracking_env_cfg.py
+++ b/agile/rl_env/tasks/stand_up/g1/height_tracking_env_cfg.py
@@ -1,0 +1,765 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import math
+
+import isaaclab.sim as sim_utils
+from isaaclab.assets import AssetBaseCfg
+from isaaclab.envs import ManagerBasedRLEnvCfg
+from isaaclab.managers import CurriculumTermCfg as CurrTerm
+from isaaclab.managers import EventTermCfg as EventTerm
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.managers import TerminationTermCfg as DoneTerm
+from isaaclab.scene import InteractiveSceneCfg
+from isaaclab.sensors import ContactSensorCfg, RayCasterCfg, patterns
+from isaaclab.terrains import TerrainImporterCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.assets import ISAAC_NUCLEUS_DIR, ISAACLAB_NUCLEUS_DIR
+from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+
+from agile.rl_env import mdp
+from agile.rl_env.assets.robots import unitree_g1
+from agile.rl_env.mdp.terrains import STAND_UP_ROUGH_TERRAIN_G1_CFG
+
+# Task-specific illegal contact links (not shared across robots/tasks)
+ILLEGAL_CONTACTS_LINKS = [
+    ".*wrist.*",
+]
+
+
+@configclass
+class SceneCfg(InteractiveSceneCfg):
+    """Configuration for the terrain scene with a legged robot."""
+
+    # ground terrain
+    terrain = TerrainImporterCfg(
+        prim_path="/World/ground",
+        terrain_type="generator",
+        terrain_generator=STAND_UP_ROUGH_TERRAIN_G1_CFG,
+        max_init_terrain_level=0,
+        collision_group=-1,
+        physics_material=sim_utils.RigidBodyMaterialCfg(
+            friction_combine_mode="multiply",
+            restitution_combine_mode="multiply",
+            static_friction=1.0,
+            dynamic_friction=1.0,
+            restitution=1.0,
+        ),
+        visual_material=sim_utils.MdlFileCfg(
+            mdl_path=(
+                f"{ISAACLAB_NUCLEUS_DIR}/Materials/TilesMarbleSpiderWhiteBrickBondHoned/"
+                f"TilesMarbleSpiderWhiteBrickBondHoned.mdl"
+            ),
+            project_uvw=True,
+            texture_scale=(0.25, 0.25),
+        ),
+        debug_vis=False,
+    )
+
+    # robots
+    robot = unitree_g1.G1_29DOF_HEIGHT_TRACKING.replace(prim_path="{ENV_REGEX_NS}/Robot")
+
+    # sensors
+    contact_forces = ContactSensorCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/.*",
+        history_length=3,
+        track_air_time=True,
+    )
+
+    # lights
+    sky_light = AssetBaseCfg(
+        prim_path="/World/skyLight",
+        spawn=sim_utils.DomeLightCfg(
+            intensity=750.0,
+            texture_file=f"{ISAAC_NUCLEUS_DIR}/Materials/Textures/Skies/PolyHaven/kloofendal_43d_clear_puresky_4k.hdr",
+        ),
+    )
+
+    height_measurement_sensor = RayCasterCfg(
+        prim_path="{ENV_REGEX_NS}/Robot/pelvis",
+        offset=RayCasterCfg.OffsetCfg(pos=(0.0, 0.0, 0.0)),
+        ray_alignment="yaw",
+        pattern_cfg=patterns.GridPatternCfg(resolution=0.05, size=(0.0, 0.0)),
+        debug_vis=False,
+        mesh_prim_paths=["/World/ground"],
+        max_distance=5.0,
+    )
+
+
+@configclass
+class CommandsCfg:
+    """Command specifications for the MDP."""
+
+    height = mdp.SmoothHeightCommandCfg(
+        asset_name="robot",
+        body_name="torso_link",
+        offset=mdp.SmoothHeightCommandCfg.OffsetCfg(pos=(0.0, 0.0, 0.20)),
+        height_sensor="height_measurement_sensor",
+        resampling_time_range=(1.0, 7.0),
+        ranges=mdp.SmoothHeightCommandCfg.Ranges(height=(-0.5, unitree_g1.DEFAULT_PELVIS_HEIGHT + 0.2)),
+        velocity_range=(1000.0, 1000.0),  # instant height jumps (no ramp)
+        debug_vis=True,
+        standing_ratio=0.3,
+        flat_ratio=0.2,
+        settle_time_s=2.0,
+    )
+
+
+@configclass
+class ObservationsCfg:
+    """Observation specifications for the MDP."""
+
+    @configclass
+    class PolicyObservationCfg(ObsGroup):
+        """Observations for policy group."""
+
+        # observation terms (order preserved)
+        base_ang_vel = ObsTerm(func=mdp.base_ang_vel, scale=0.2, noise=Unoise(n_min=-0.2, n_max=0.2))
+        projected_gravity = ObsTerm(func=mdp.projected_gravity, noise=Unoise(n_min=-0.05, n_max=0.05))
+        joint_pos = ObsTerm(
+            func=mdp.joint_pos_rel,
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        )
+        joint_vel = ObsTerm(
+            func=mdp.joint_vel_rel,
+            scale=0.05,
+            noise=Unoise(n_min=-1.5, n_max=1.5),
+        )
+        actions = ObsTerm(func=mdp.last_action, clip=(-100, 100))
+        height_command = ObsTerm(
+            func=mdp.generated_commands,
+            params={"command_name": "height"},
+        )
+
+        def __post_init__(self):
+            self.history_length = 5
+            self.enable_corruption = True
+            self.concatenate_terms = False
+            self.flatten_history_dim = False
+
+    @configclass
+    class CriticObservationsCfg(ObsGroup):
+        """Observations for critic group."""
+
+        projected_gravity = ObsTerm(func=mdp.projected_gravity)
+        base_lin_vel = ObsTerm(func=mdp.base_lin_vel)
+        base_ang_vel = ObsTerm(func=mdp.base_ang_vel)
+        joint_pos = ObsTerm(func=mdp.joint_pos_rel)
+        joint_vel = ObsTerm(func=mdp.joint_vel_rel, scale=0.05)
+        actions = ObsTerm(func=mdp.last_action, clip=(-100, 100))
+        contact_forces = ObsTerm(
+            func=mdp.contact_force_norm,
+            params={
+                "sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*"),
+            },
+            scale=5e-3,
+            clip=(-25_000.0, 25_000.0),
+        )
+        base_height = ObsTerm(
+            func=mdp.base_height_from_sensor,
+            params={"sensor_cfg": SceneEntityCfg("height_measurement_sensor")},
+            clip=(-2, 2),
+        )
+        height_command = ObsTerm(
+            func=mdp.generated_commands,
+            params={"command_name": "height"},
+        )
+
+        def __post_init__(self):
+            self.history_length = 5
+            self.enable_corruption = False
+            self.concatenate_terms = False
+            self.flatten_history_dim = False
+
+    policy: PolicyObservationCfg = PolicyObservationCfg()
+    critic: CriticObservationsCfg = CriticObservationsCfg()
+
+
+@configclass
+class ActionsCfg:
+    """Action specifications for the MDP."""
+
+    joint_pos = mdp.JointPositionActionCfg(
+        asset_name="robot",
+        joint_names=[".*"],
+        scale=unitree_g1.G1_NO_HANDS_AGILE_ACTION_SCALE,
+        use_default_offset=True,
+        clip={".*": (-6.0, 6.0)},
+    )
+
+    lift = mdp.LiftActionCfg(
+        asset_name="robot",
+        link_to_lift="torso_link",
+        stiffness_forces=5000.0,
+        damping_forces=2500.0,
+        force_limit_weight_fraction=0.9,
+        damping_torques=100.0,
+        torque_limit=250.0,
+        height_sensor="height_measurement_sensor",
+        target_height=unitree_g1.DEFAULT_PELVIS_HEIGHT,
+        height_command="height",
+        force_offset=(0.0, 0.0, 0.5),
+        allow_push_down=True,
+    )
+
+
+@configclass
+class RewardsCfg:
+    """Reward terms for the MDP."""
+
+    # Regularization:
+    joint_torques_l2 = RewTerm(func=mdp.joint_torques_l2, weight=-0.5e-4)
+    torque_limits = RewTerm(func=mdp.applied_torque_limits, weight=-0.01)
+    joint_acc_l2 = RewTerm(func=mdp.joint_acc_l2, weight=-2.5e-8)
+    joint_pos_limits = RewTerm(func=mdp.joint_pos_limits, weight=-0.1)
+    joint_vel_limits = RewTerm(func=mdp.joint_vel_limits, weight=-0.01, params={"soft_ratio": 0.8})
+    action_rate = RewTerm(func=mdp.action_rate_l2, weight=-1.0)
+    action_rate_rate = RewTerm(
+        func=mdp.action_rate_rate_l2,
+        weight=-0.15,
+        params={"asset_cfg": SceneEntityCfg("robot")},
+    )
+    joint_vel_l2 = RewTerm(func=mdp.joint_vel_l2, weight=-1e-3)
+    joint_tracking_error = RewTerm(func=mdp.joint_pos_tracking_error_l2, weight=-0.5)
+
+    # Task: command-tracking height rewards (multi-scale for stable gradient signal)
+    base_height_rough = RewTerm(
+        func=mdp.track_height_command_exp,
+        weight=4.0,
+        params={"command_name": "height", "std": 0.5},
+    )
+    base_height_medium = RewTerm(
+        func=mdp.track_height_command_exp,
+        weight=8.0,
+        params={"command_name": "height", "std": 0.3},
+    )
+    base_height_fine = RewTerm(
+        func=mdp.track_height_command_exp,
+        weight=16.0,
+        params={"command_name": "height", "std": 0.2},
+    )
+    relaxation = RewTerm(
+        func=mdp.relaxation_penalty,
+        weight=-1.0,
+        params={
+            "command_name": "height",
+            "asset_cfg": SceneEntityCfg("robot"),
+            "pos_weight": 1.0,
+            "torque_weight": 1e-3,
+        },
+    )
+
+    # Aesthetics:
+    joint_deviation_l1 = RewTerm(
+        func=mdp.joint_deviation_if_standing,
+        weight=-0.5,
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "standing_height_threshold": 0.5,
+            "sensor_cfg": SceneEntityCfg("height_measurement_sensor"),
+            "mode": "l1",
+        },
+    )
+    joint_deviation_l1_arms = RewTerm(
+        func=mdp.joint_deviation_if_standing,
+        weight=-0.5,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                joint_names=unitree_g1.ARM_JOINT_NAMES,
+            ),
+            "standing_height_threshold": 0.4,
+            "sensor_cfg": SceneEntityCfg("height_measurement_sensor"),
+            "mode": "l1",
+        },
+    )
+    ankle_torques = RewTerm(
+        func=mdp.joint_torques_l2,
+        weight=-1e-3,
+        params={"asset_cfg": SceneEntityCfg("robot", joint_names=".*ankle.*")},
+    )
+    # Penalize movement when tracking error is low (robot reached target)
+    not_moving = RewTerm(
+        func=mdp.moving_if_tracking,
+        weight=-1.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "command_name": "height",
+            "error_threshold": 0.1,
+            "weight_lin": 1.0,
+            "weight_ang": 1.0,
+        },
+    )
+    # Upright torso at moderate+ heights (not when lying down)
+    torso_upright = RewTerm(
+        func=mdp.upright_orientation_after_standing,
+        weight=-1.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=["torso_link"]),
+            "standing_height_threshold": 0.4,
+            "min_standing_duration_s": 1.0,
+            "sensor_cfg": SceneEntityCfg("height_measurement_sensor"),
+            "norm": "l1",
+        },
+    )
+    severely_tilted = RewTerm(
+        func=mdp.severely_tilted_penalty,
+        weight=-5.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=["pelvis", "torso_link"]),
+            "threshold_rad": math.radians(135),
+        },
+    )
+    torso_roll = RewTerm(
+        func=mdp.body_orientation_penalty,
+        weight=-5.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=["torso_link"]),
+            "axis": "roll",
+            "direction": "both",
+            "kernel": "l1",
+        },
+    )
+    forward_pitch = RewTerm(
+        func=mdp.body_orientation_penalty,
+        weight=-10.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=["torso_link"]),
+            "axis": "pitch",
+            "direction": "forward",
+            "kernel": "l2",
+        },
+    )
+    illegal_contacts = RewTerm(
+        func=mdp.illegal_contact,
+        weight=-2.0,
+        params={
+            "sensor_cfg": SceneEntityCfg("contact_forces", body_names=ILLEGAL_CONTACTS_LINKS),
+            "threshold": 1.0,
+        },
+    )
+    feet_distance = RewTerm(
+        func=mdp.feet_distance_from_ref,
+        weight=-5.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=unitree_g1.FEET_LINK_NAMES),
+            "ref_distance": 0.2,
+            "norm": "l2",
+            "error_threshold": 0.2,
+            "distance_mode": "absolute",
+            "close_multiplier": 5.0,
+            "episode_delay_s": 1.0,
+            "episode_ramp_s": 2.0,
+        },
+    )
+    feet_distance_standing = RewTerm(
+        func=mdp.feet_distance_from_ref_if_standing,
+        weight=-10.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=unitree_g1.FEET_LINK_NAMES),
+            "ref_distance": 0.2,
+            "norm": "l2",
+            "error_threshold": 0.2,
+            "distance_mode": "absolute",
+            "close_multiplier": 5.0,
+            "standing_height_threshold": 0.4,
+            "sensor_cfg": SceneEntityCfg("height_measurement_sensor"),
+            "episode_delay_s": 1.0,
+            "episode_ramp_s": 2.0,
+        },
+    )
+    ground_unloaded = RewTerm(
+        func=mdp.ground_unloaded,
+        weight=-2.0,
+        params={
+            "sensor_cfg": SceneEntityCfg("contact_forces", body_names=unitree_g1.FEET_LINK_NAMES),
+            "asset_cfg": SceneEntityCfg("robot"),
+            "command_name": "height",
+        },
+    )
+    flat_feet = RewTerm(
+        func=mdp.foot_orientation_l1,
+        weight=-1.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=unitree_g1.FEET_LINK_NAMES),
+            "roll_weight": 1.0,
+            "pitch_weight": 2.0,
+            "yaw_weight": 0.0,
+        },
+    )
+    feet_slide = RewTerm(
+        func=mdp.feet_slide,
+        weight=-1.0,
+        params={
+            "sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*ankle_roll_link"),
+            "asset_cfg": SceneEntityCfg("robot", body_names=".*ankle_roll_link"),
+        },
+    )
+
+    feet_yaw_mean = RewTerm(
+        func=mdp.feet_yaw_mean_vs_base,
+        weight=-2.0,
+        params={
+            "feet_asset_cfg": SceneEntityCfg("robot", body_names=unitree_g1.FEET_LINK_NAMES),
+            "base_body_cfg": SceneEntityCfg("robot", body_names="pelvis"),
+        },
+    )
+    # Severe binary penalty for being completely airborne (no body touching ground at all)
+    completely_airborne = RewTerm(
+        func=mdp.completely_airborne,
+        weight=-50.0,
+        params={
+            "sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*"),
+            "threshold": 1.0,
+        },
+    )
+    # Dense quasi-static motion penalty: all major body parts should move slowly
+    body_velocity = RewTerm(
+        func=mdp.bodies_lin_vel_l2,
+        weight=-0.1,
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=[
+                    "pelvis",
+                    "torso_link",
+                    ".*_hip_pitch_link",
+                    ".*_hip_roll_link",
+                    ".*_hip_yaw_link",
+                    ".*_knee_link",
+                    ".*wrist.*",
+                ],
+            ),
+            "threshold": 0.3,
+        },
+    )
+    # Sparse impact penalty: penalize velocity at moment of ground contact (uses velocity history buffer)
+    ground_slam = RewTerm(
+        func=mdp.impact_velocity,
+        weight=-1.0,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=[
+                    "pelvis",
+                    "torso_link",
+                    ".*_hip_pitch_link",
+                    ".*_hip_roll_link",
+                    ".*_hip_yaw_link",
+                    ".*_knee_link",
+                    ".*ankle_roll_link",
+                ],
+            ),
+            "force_threshold": 10.0,
+            "kernel": "l2",
+        },
+    )
+    # Extra penalty for torso/pelvis impact — these should never slam the ground
+    torso_slam = RewTerm(
+        func=mdp.impact_velocity,
+        weight=-5.0,
+        params={
+            "sensor_cfg": SceneEntityCfg(
+                "contact_forces",
+                body_names=["pelvis", "torso_link"],
+            ),
+            "force_threshold": 10.0,
+            "kernel": "l2",
+        },
+    )
+
+
+@configclass
+class TerminationsCfg:
+    """Termination terms for the MDP."""
+
+    time_out = DoneTerm(func=mdp.time_out, time_out=True)
+
+    invalid_state = DoneTerm(
+        func=mdp.invalid_state,
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "max_joint_vel": 100.0,
+            "max_root_height": 5.0,
+            "max_root_xy_distance": 200.0,
+            "max_lin_vel": 20.0,
+            "max_ang_vel": 50.0,
+        },
+    )
+
+
+@configclass
+class EventCfg:
+    """Configuration for events."""
+
+    # startup
+    randomize_physics_material = EventTerm(
+        func=mdp.randomize_rigid_body_material,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "static_friction_range": (0.2, 1.5),
+            "dynamic_friction_range": (0.2, 1.0),
+            "restitution_range": (0.0, 0.1),
+            "num_buckets": 64,
+        },
+    )
+    randomize_actuator_gains = EventTerm(
+        func=mdp.randomize_actuator_gains,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot"),
+            "stiffness_distribution_params": (0.9, 1.1),
+            "damping_distribution_params": (0.8, 2.0),
+            "operation": "scale",
+        },
+    )
+    randomize_bodies_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=".*"),
+            "mass_distribution_params": (0.95, 1.05),
+            "operation": "scale",
+        },
+    )
+    randomize_base_mass = EventTerm(
+        func=mdp.randomize_rigid_body_mass,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names="torso_link"),
+            "mass_distribution_params": (-1.0, 3.0),
+            "operation": "add",
+        },
+    )
+    randomize_base_com = EventTerm(
+        func=mdp.randomize_rigid_body_com,
+        mode="startup",
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names="torso_link"),
+            "com_range": {"x": (-0.1, 0.1), "y": (-0.05, 0.05), "z": (-0.1, 0.1)},
+        },
+    )
+
+    # interval
+    push_robot = EventTerm(
+        func=mdp.push_by_setting_velocity,
+        mode="interval",
+        interval_range_s=(0.0, 10.0),
+        params={
+            "velocity_range": {
+                "x": (-1.0, 1.0),
+                "y": (-1.0, 1.0),
+                "roll": (-0.5, 0.5),
+                "pitch": (-0.5, 0.5),
+                "yaw": (-0.5, 0.5),
+            }
+        },
+    )
+    apply_external_force_torque = EventTerm(
+        func=mdp.apply_external_force_torque,
+        mode="interval",
+        interval_range_s=(0.0, 10.0),
+        params={
+            "asset_cfg": SceneEntityCfg(
+                "robot",
+                body_names=[
+                    "torso_link",
+                ],
+            ),
+            "force_range": (-20.0, 20.0),
+            "torque_range": (-10.0, 10.0),
+        },
+    )
+    apply_external_force_torque_extremities = EventTerm(
+        func=mdp.apply_external_force_torque,
+        mode="interval",
+        interval_range_s=(0.0, 10.0),
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=[".*wrist_yaw_link.*", ".*ankle_roll_link.*"]),
+            "force_range": (-5.0, 5.0),
+            "torque_range": (-0.5, 0.5),
+        },
+    )
+
+    # reset
+    reset_base = EventTerm(
+        func=mdp.reset_from_fallen_dataset,
+        mode="reset",
+        params={
+            "standing_ratio": 0.5,
+            "height_offset": 0.05,
+            "random_fallen_ratio": 0.0,
+        },
+    )
+
+
+@configclass
+class CurriculumCfg:
+    """Curriculum terms for the MDP."""
+
+    adaptive_lift = CurrTerm(
+        func=mdp.adaptive_force_decay,
+        params={
+            "action_name": "lift",
+            "metric_name": "height_error",
+            "decay_when": "below",
+            "threshold": 0.1,
+            "command_name": "height",
+            "ema_alpha": 0.05,
+            "decay": 0.9999,
+            "disable_threshold": 0.01,
+        },
+    )
+
+    terrain_levels = CurrTerm(
+        func=mdp.terrain_levels_tracking_at_timeout,
+        params={
+            "command_name": "height",
+            "error_threshold": 0.1,
+            "n_successes": 5,
+            "n_failures": 5,
+            "prerequisite_curriculum": "adaptive_lift",
+            "prerequisite_threshold": 0.01,
+            "prerequisite_direction": "below",
+        },
+    )
+
+    # Polish phase: once terrain is mastered (level >= 4.0), ramp up penalties
+    # ~1000 iterations = 24000 steps per curriculum for gradual adaptation
+    polish_action_rate_rate = CurrTerm(
+        func=mdp.update_reward_weight_after_curriculum,
+        params={
+            "reward_name": "action_rate_rate",
+            "terminal_weight": -0.5,
+            "prerequisite_curriculum": "terrain_levels",
+            "prerequisite_threshold": 4.0,
+            "delay_steps": 1750,
+            "num_steps": 24000,
+        },
+    )
+    polish_ground_slam = CurrTerm(
+        func=mdp.update_reward_weight_after_curriculum,
+        params={
+            "reward_name": "ground_slam",
+            "terminal_weight": -3.0,
+            "prerequisite_curriculum": "terrain_levels",
+            "prerequisite_threshold": 4.0,
+            "delay_steps": 1500,
+            "num_steps": 24000,
+        },
+    )
+    polish_torso_slam = CurrTerm(
+        func=mdp.update_reward_weight_after_curriculum,
+        params={
+            "reward_name": "torso_slam",
+            "terminal_weight": -250.0,
+            "prerequisite_curriculum": "terrain_levels",
+            "prerequisite_threshold": 4.0,
+            "delay_steps": 1250,
+            "num_steps": 24000,
+        },
+    )
+    polish_not_moving = CurrTerm(
+        func=mdp.update_reward_weight_after_curriculum,
+        params={
+            "reward_name": "not_moving",
+            "terminal_weight": -2.5,
+            "prerequisite_curriculum": "terrain_levels",
+            "prerequisite_threshold": 4.0,
+            "delay_steps": 1750,
+            "num_steps": 24000,
+        },
+    )
+    polish_joint_vel_l2 = CurrTerm(
+        func=mdp.update_reward_weight_after_curriculum,
+        params={
+            "reward_name": "joint_vel_l2",
+            "terminal_weight": -0.5e-1,
+            "prerequisite_curriculum": "terrain_levels",
+            "prerequisite_threshold": 4.0,
+            "delay_steps": 1500,
+            "num_steps": 24000,
+        },
+    )
+
+    # ~2000 iterations = 48000 steps for random fallen states ramp
+    random_fallen_states = CurrTerm(
+        func=mdp.update_event_param_after_curriculum,
+        params={
+            "event_term": "reset_base",
+            "param_name": "random_fallen_ratio",
+            "terminal_value": 0.5,
+            "prerequisite_curriculum": "terrain_levels",
+            "prerequisite_threshold": 3.0,
+            "delay_steps": 2000,
+            "num_steps": 48000,
+        },
+    )
+
+
+@configclass
+class ViewerCfg:
+    """Configuration of the scene viewport camera."""
+
+    eye: tuple[float, float, float] = (0.0, -6.0, 3.0)
+    lookat: tuple[float, float, float] = (0.0, 25.0, -5.0)
+    cam_prim_path: str = "/OmniverseKit_Persp"
+    resolution: tuple[int, int] = (1280, 720)
+    origin_type = "asset_root"
+    asset_name: str = "robot"
+    env_index: int = 0
+
+
+@configclass
+class G1HeightTrackingEnvCfg(ManagerBasedRLEnvCfg):
+    scene: SceneCfg = SceneCfg(num_envs=4096, env_spacing=2.5)
+
+    # Basic settings
+    observations: ObservationsCfg = ObservationsCfg()
+    actions: ActionsCfg = ActionsCfg()
+    commands: CommandsCfg = CommandsCfg()
+
+    # MDP settings
+    rewards: RewardsCfg = RewardsCfg()
+    terminations: TerminationsCfg = TerminationsCfg()
+    events: EventCfg = EventCfg()
+    curriculum: CurriculumCfg = CurriculumCfg()
+    viewer: ViewerCfg = ViewerCfg()
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.decimation = 4
+        self.episode_length_s = 15.0
+        self.sim.dt = 1 / 200
+        self.sim.render_interval = self.decimation
+        self.sim.physics_material = self.scene.terrain.physics_material
+        self.scene.contact_forces.update_period = self.sim.dt
+
+        self.sim.physx.gpu_max_rigid_patch_count = 2**20
+
+        if self.scene.height_measurement_sensor is not None:
+            self.scene.height_measurement_sensor.update_period = self.sim.dt
+
+        if getattr(self.curriculum, "terrain_levels", None) is not None:
+            if self.scene.terrain.terrain_generator is not None:
+                self.scene.terrain.terrain_generator.curriculum = True
+        else:
+            if self.scene.terrain.terrain_generator is not None:
+                self.scene.terrain.terrain_generator.curriculum = False

--- a/agile/rl_env/tasks/stand_up/g1/pre_learn.py
+++ b/agile/rl_env/tasks/stand_up/g1/pre_learn.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pre-learn hook for stand-up task to collect fallen states before training."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from agile.rl_env.mdp.events import (
+    FallenStateDataset,
+    FallenStateDatasetCfg,
+    compute_fallen_state_cache_key,
+    get_fallen_state_cache_path,
+    reset_from_fallen_dataset,
+)
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from isaaclab.envs import ManagerBasedRLEnv
+
+
+def pre_learn(env: ManagerBasedRLEnv, task_name: str, agent_cfg) -> None:
+    """Pre-learn hook called before training starts.
+
+    This function sets up the fallen state dataset for efficient resets.
+    It pre-collects diverse fallen poses so episodes can reset instantly
+    instead of simulating 5 seconds of falling each time.
+
+    Optionally sets up a secondary dataset (e.g., random-orientation fallen states)
+    for dual-dataset curriculum training.
+
+    Args:
+        env: The unwrapped environment instance.
+        task_name: Name of the task (e.g., 'StandUp-T1-v0', 'StandUp-G1-v0').
+        agent_cfg: The agent configuration object.
+    """
+    # Check if fallen state dataset is configured
+    dataset_cfg: FallenStateDatasetCfg | None = getattr(agent_cfg, "fallen_state_dataset_cfg", None)
+    if dataset_cfg is None:
+        return
+
+    # Get the reset_from_fallen_dataset event term
+    reset_event = _get_reset_event(env)
+
+    # Setup primary dataset
+    dataset = _setup_dataset(env, task_name, dataset_cfg, "primary")
+    reset_event.set_dataset(dataset)
+
+    # Setup secondary dataset if configured
+    secondary_cfg: FallenStateDatasetCfg | None = getattr(agent_cfg, "fallen_state_dataset_secondary_cfg", None)
+    if secondary_cfg is not None:
+        secondary_dataset = _setup_dataset(env, task_name, secondary_cfg, "secondary")
+        reset_event.set_secondary_dataset(secondary_dataset)
+
+
+def _setup_dataset(
+    env: ManagerBasedRLEnv,
+    task_name: str,
+    dataset_cfg: FallenStateDatasetCfg,
+    label: str,
+) -> FallenStateDataset:
+    """Create, load from cache, or collect a fallen state dataset.
+
+    Args:
+        env: The environment instance.
+        task_name: Name of the task.
+        dataset_cfg: Configuration for the dataset.
+        label: Human-readable label for logging (e.g., "primary", "secondary").
+
+    Returns:
+        The ready-to-use dataset.
+    """
+    dataset = FallenStateDataset(cfg=dataset_cfg)
+
+    # Try to load from cache
+    if dataset_cfg.cache_enabled:
+        cache_path = _get_cache_path(env, task_name, dataset_cfg)
+
+        if dataset.load(cache_path):
+            logger.info(f"Loaded {label} fallen state dataset from cache: {cache_path}")
+            return dataset
+
+        logger.info(f"No valid cache found for {label} dataset at {cache_path}, will collect new dataset.")
+
+    # Collect new dataset
+    logger.info(f"Starting {label} fallen state collection...")
+    dataset.collect(env, verbose=True)
+
+    # Save to cache
+    if dataset_cfg.cache_enabled:
+        cache_path = _get_cache_path(env, task_name, dataset_cfg)
+        dataset.save(cache_path)
+        logger.info(f"Saved {label} fallen state dataset to cache: {cache_path}")
+
+    return dataset
+
+
+def _get_reset_event(env: ManagerBasedRLEnv) -> reset_from_fallen_dataset:
+    """Get the reset_from_fallen_dataset event term from the environment.
+
+    Raises:
+        AssertionError: If the event term is not found.
+    """
+    event_manager = env.event_manager
+
+    if "reset" in event_manager.active_terms:
+        for term_name in event_manager.active_terms["reset"]:
+            term_cfg = event_manager.get_term_cfg(term_name)
+            # For class-based terms, term_cfg.func is the instance
+            if isinstance(term_cfg.func, reset_from_fallen_dataset):
+                return term_cfg.func
+
+    raise AssertionError(
+        "No reset_from_fallen_dataset event term found in environment. "
+        "Add EventTerm(func=mdp.reset_from_fallen_dataset, ...) to your EventsCfg."
+    )
+
+
+def _get_cache_path(env: ManagerBasedRLEnv, task_name: str, dataset_cfg: FallenStateDatasetCfg) -> str:
+    """Compute the cache path for fallen states, differentiated by dataset config."""
+    terrain_cfg = None
+    if hasattr(env.scene, "terrain") and env.scene.terrain is not None:
+        terrain_gen = env.scene.terrain.cfg.terrain_generator
+        if terrain_gen is not None:
+            # Use full terrain config for cache key to ensure invalidation on any change
+            # This includes all sub_terrain parameters (roughness, height, etc.)
+            terrain_cfg = _serialize_terrain_config(terrain_gen)
+
+    # Every FallenStateDatasetCfg field that influences the collected states goes into
+    # the cache key; infrastructure fields (cache_enabled, cache_dir) are excluded.
+    dataset_cfg_dict = {
+        "spawn_orientation": dataset_cfg.spawn_orientation,
+        "spawn_joint_mode": dataset_cfg.spawn_joint_mode,
+        "initial_lin_vel_range": dataset_cfg.initial_lin_vel_range,
+        "initial_ang_vel_range": dataset_cfg.initial_ang_vel_range,
+        "spawn_pitch_range": list(dataset_cfg.spawn_pitch_range),
+        "num_spawns_per_level": dataset_cfg.num_spawns_per_level,
+        "fall_duration_s": dataset_cfg.fall_duration_s,
+        "spawn_height_offset": dataset_cfg.spawn_height_offset,
+        "spawn_xy_range": dataset_cfg.spawn_xy_range,
+        "max_height_above_spawn": dataset_cfg.max_height_above_spawn,
+        "max_lin_vel": dataset_cfg.max_lin_vel,
+        "max_ang_vel": dataset_cfg.max_ang_vel,
+        "max_joint_vel": dataset_cfg.max_joint_vel,
+    }
+
+    cache_key = compute_fallen_state_cache_key(task_name, terrain_cfg, dataset_cfg_dict)
+    return get_fallen_state_cache_path(dataset_cfg.cache_dir, cache_key)
+
+
+def _serialize_terrain_config(terrain_gen) -> dict:
+    """Serialize terrain generator config for deterministic cache key computation.
+
+    Converts the terrain config to a dictionary, filtering out non-serializable
+    fields (like class references) while preserving all parameter values that
+    affect terrain generation.
+    """
+    # Use configclass's to_dict() for deep serialization
+    terrain_dict = terrain_gen.to_dict()
+
+    # Filter out non-serializable fields that don't affect terrain geometry
+    keys_to_remove = ["class_type", "use_cache", "cache_dir"]
+    for key in keys_to_remove:
+        terrain_dict.pop(key, None)
+
+    # Also filter class_type from sub_terrains
+    if "sub_terrains" in terrain_dict and terrain_dict["sub_terrains"]:
+        for sub_terrain_cfg in terrain_dict["sub_terrains"].values():
+            if isinstance(sub_terrain_cfg, dict):
+                sub_terrain_cfg.pop("class_type", None)
+                sub_terrain_cfg.pop("function", None)
+
+    return terrain_dict

--- a/tests/test_all_tasks_e2e.py
+++ b/tests/test_all_tasks_e2e.py
@@ -98,6 +98,8 @@ class TestAllTasks(unittest.TestCase):
             "Velocity-T1-v0",
             # T1 Robot - Stand Up
             "StandUp-T1-v0",
+            # G1 Robot - Stand Up / Lie Down via Height Tracking
+            "HeightTracking-G1-v0",
             # G1 Robot - Pick and Place - Tracking
             "G1-PickPlace-Tracking-v0",
             # ====================================================================
@@ -177,13 +179,22 @@ class TestAllTasks(unittest.TestCase):
                     env["OMNI_HEADLESS"] = "1"
                     env["DISPLAY"] = ":1"
 
-                    # Add fast fallen state collection overrides for StandUp tasks
-                    if "StandUp" in task:
+                    # Add fast fallen state collection overrides for tasks using FallenStateDataset
+                    if "StandUp" in task or "HeightTracking" in task:
                         cmd.extend(
                             [
                                 "agent.fallen_state_dataset_cfg.num_spawns_per_level=1",
                                 "agent.fallen_state_dataset_cfg.fall_duration_s=0.1",
                                 "agent.fallen_state_dataset_cfg.cache_enabled=False",
+                            ]
+                        )
+                    # HeightTracking has a secondary (random-orientation) dataset on top
+                    if "HeightTracking" in task:
+                        cmd.extend(
+                            [
+                                "agent.fallen_state_dataset_secondary_cfg.num_spawns_per_level=1",
+                                "agent.fallen_state_dataset_secondary_cfg.fall_duration_s=0.1",
+                                "agent.fallen_state_dataset_secondary_cfg.cache_enabled=False",
                             ]
                         )
 


### PR DESCRIPTION
## Summary
Adds a new G1 task for stand-up and lie-down via height tracking. The task uses a pre-collected fallen-state dataset (with a secondary random-orientation dataset for diversity) to enable efficient episode resets without simulating falls at training time.

Closes #52

## Changes
- New task: `HeightTracking-G1-v0` registered in `agile/rl_env/tasks/stand_up/g1/`
- Extended `LiftAction` with `force_offset` to apply lift force above the body origin (e.g. at the chest instead of the pelvis)
- Enhanced `FallenStateDataset` and reset event with support for:
  - Secondary dataset (dual-dataset curriculum mixing)
  - Additional configuration knobs (spawn_joint_mode, orientation control)
- New pre_learn hook that sets up both primary and secondary fallen-state datasets
- E2E test: fast fallen-state overrides applied to both StandUp and HeightTracking tasks
- Added missing `Articulation` import in regularization_rewards.py (was used but not imported)

## Test plan
- [x] Pre-commit hooks pass locally
- [ ] E2E test passes: `./tests/test_e2e_ci_locally.sh --task HeightTracking-G1-v0`
- [ ] Policy converges on stand-up from fallen states

Signed-off-by: Rafael Cathomen <rcathomen@nvidia.com>