### PR TITLE
[fix] Upgrade Isaac Lab from 2.3.1 to 2.3.2

### DIFF
--- a/agile/rl_env/mdp/actions/lift_action.py
+++ b/agile/rl_env/mdp/actions/lift_action.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+import isaaclab.utils.math as math_utils
 from isaaclab.assets.articulation import Articulation
 from isaaclab.managers.action_manager import ActionTerm
 from isaaclab.sensors import RayCaster
@@ -192,11 +193,16 @@ class LiftAction(ActionTerm):
             # Clamp torques
             torques_w[:, 2] = torch.clamp(torques_w[:, 2], -self._torque_limit, self._torque_limit)
 
-        # Isaac Lab 2.3.1 does not expose permanent_wrench_composer, so we fall back to
-        # set_external_force_and_torque which applies the wrench at the body origin.
-        # The force_offset field is not respected in this code path.
-        self._asset.set_external_force_and_torque(
-            forces=forces, torques=torques_w.unsqueeze(1), body_ids=self._lift_link_id, is_global=True
+        # rotate forces and torques to body frame
+        link_quat = self._asset.data.body_quat_w[:, self._lift_link_id].squeeze(1)
+        forces_b = math_utils.quat_apply_inverse(link_quat, forces)
+        torques_b = math_utils.quat_apply_inverse(link_quat, torques_w.unsqueeze(1))
+
+        # Compute positions for force application (offset from body origin in local frame)
+        positions = self._force_offset.unsqueeze(0).unsqueeze(0).expand(forces_b.shape[0], 1, 3)
+
+        self._asset.permanent_wrench_composer.set_forces_and_torques(
+            forces=forces_b, torques=torques_b, positions=positions, body_ids=self._lift_link_id
         )
 
     def reset(self, env_ids: Sequence[int] | None = None) -> None:

--- a/scripts/setup/install_deps.sh
+++ b/scripts/setup/install_deps.sh
@@ -51,7 +51,7 @@ echo "📝 For local development, use ./scripts/setup/install_deps_local.sh inst
 
 # Check that IsaacLab is using the correct version.
 if [ -d ${ISAACLAB_PATH}/.git ]; then
-  expected_isaac_lab_tag="v2.3.1"
+  expected_isaac_lab_tag="v2.3.2"
   if ! git -C ${ISAACLAB_PATH} tag -l "${expected_isaac_lab_tag}" | grep -q "${expected_isaac_lab_tag}"; then
       echo "Error: IsaacLab does not have the expected tag."
       echo "Expected tag: ${expected_isaac_lab_tag}"

--- a/scripts/setup/install_deps_local.sh
+++ b/scripts/setup/install_deps_local.sh
@@ -46,7 +46,7 @@ fi
 
 # Check that IsaacLab is using the correct version.
 if [ -d ${ISAACLAB_PATH}/.git ]; then
-  expected_isaac_lab_tag="v2.3.1"
+  expected_isaac_lab_tag="v2.3.2"
   if ! git -C ${ISAACLAB_PATH} tag -l "${expected_isaac_lab_tag}" | grep -q "${expected_isaac_lab_tag}"; then
       echo "Error: IsaacLab does not have the expected tag."
       echo "Expected tag: ${expected_isaac_lab_tag}"

--- a/tests/test_e2e_ci_locally.sh
+++ b/tests/test_e2e_ci_locally.sh
@@ -26,7 +26,7 @@ NC='\033[0m' # No Color
 echo -e "${BLUE}=== TESTING E2E IN CI ENVIRONMENT LOCALLY ===${NC}"
 
 # Docker image used in CI
-DOCKER_IMAGE="nvcr.io/nvidia/isaac-lab:2.3.1"
+DOCKER_IMAGE="nvcr.io/nvidia/isaac-lab:2.3.2"
 
 echo -e "${YELLOW}This will pull and run the Docker image: ${DOCKER_IMAGE}${NC}"
 echo -e "${YELLOW}Make sure you have Docker installed and running.${NC}"

--- a/workflows/Dockerfile
+++ b/workflows/Dockerfile
@@ -7,7 +7,7 @@ ARG RESUME_STAGE=no
 ###############################
 # Base Stage
 ###############################
-FROM nvcr.io/nvidia/isaac-lab:2.3.1 AS base
+FROM nvcr.io/nvidia/isaac-lab:2.3.2 AS base
 
 # Fix potential Vulkan conflicts
 RUN if [ -e "/usr/share/vulkan" ] && [ -e "/etc/vulkan" ]; then \


### PR DESCRIPTION
## Summary
Upgrade the pinned Isaac Lab version from 2.3.1 to 2.3.2 and migrate to the new permanent_wrench_composer API for external wrench application.

## Changes
- Update Docker base image: `nvcr.io/nvidia/isaac-lab:2.3.1` → `2.3.2` in `workflows/Dockerfile` and `tests/test_e2e_ci_locally.sh`
- Update expected Isaac Lab tag from `v2.3.1` to `v2.3.2` in `install_deps.sh` and `install_deps_local.sh`
- Migrate `lift_action.py` from the deprecated `set_external_force_and_torque` to `permanent_wrench_composer.set_forces_and_torques`. This also restores the `force_offset` support that was left out of PR #54 to keep compatibility with 2.3.1

## Test plan
- [ ] CI passes on 2.3.2 image
- [x] `python scripts/train.py --task HeightTracking-G1-v0 --num_envs 4 --headless --max_iterations 5` runs
- [x] `python scripts/train.py --task StandUp-T1-v0 --num_envs 4 --headless --max_iterations 5` runs (also uses LiftAction)

Signed-off-by: Rafael Cathomen <rcathomen@nvidia.com>