### PR TITLE
fix(rsl_rl): nan-safe std in ActorCritic scalar noise mode

### DIFF
--- a/agile/algorithms/rsl_rl/rsl_rl/modules/actor_critic.py
+++ b/agile/algorithms/rsl_rl/rsl_rl/modules/actor_critic.py
@@ -142,7 +142,9 @@ class ActorCritic(nn.Module):
         mean = self.actor(observations)
         # compute standard deviation
         if self.noise_std_type == "scalar":
-            std = torch.clamp(self.std.expand_as(mean), min=1e-6)
+            # nan_to_num closes a gap with the log/pred branches: if an upstream
+            # step leaves NaN in self.std, Normal(mean, NaN) would crash the run.
+            std = torch.clamp(torch.nan_to_num(self.std, nan=1e-2).expand_as(mean), min=1e-6)
         elif self.noise_std_type == "log":
             std = torch.exp(torch.clamp(self.log_std, min=self.log_std_range[0], max=self.log_std_range[1])).expand_as(
                 mean


### PR DESCRIPTION
The scalar noise branch of `ActorCritic.update_distribution` only clamped `self.std` against a lower bound, whereas the `log` and `pred` branches both wrap their parameter in `torch.clamp(..., min=log_std_range[0], max=log_std_range[1])`. As a result the scalar branch cannot recover when an upstream step (e.g. an outlier rollout feeding into the PPO update) leaves a NaN in `self.std`: the next forward pass calls `Normal(mean, std)` and pytorch rejects the distribution with

  RuntimeError: normal expects all elements of std >= 0.0

Wrap the parameter in `torch.nan_to_num` before the existing lower clamp so a single contaminated update can't kill a long-running job. Matches the behavior of the other two modes and has no effect on healthy runs.

Seen during a bipedal locomotion training after ~120k iterations with `num_envs=6144`. The NaN itself originates upstream in the PPO update; this patch just turns that event from a fatal crash into a numerical blip.
