### PR TITLE
[fix] Replace non-existent impact_velocity_l1 with impact_velocity

### DIFF
--- a/agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py
+++ b/agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py
@@ -475,11 +475,12 @@ class RewardsCfg:
     )
 
     impact_velocity = RewTerm(
-        func=mdp.impact_velocity_l1,
+        func=mdp.impact_velocity,
         weight=-0.5,
         params={
             "sensor_cfg": SceneEntityCfg("contact_forces", body_names=".*ankle_roll_link"),
             "force_threshold": 10.0,
+            "kernel": "l1",
         },
     )
 


### PR DESCRIPTION
## Summary

- Fix `impact_velocity` reward term in `velocity_height_env_cfg.py` that referenced the non-existent function `mdp.impact_velocity_l1`
- The correct function is `impact_velocity()` with a `kernel` parameter for selecting between `"l1"` and `"l2"` penalty modes

## Root Cause

The reward configuration called `mdp.impact_velocity_l1`, but this function does not exist in `agile/rl_env/mdp/rewards/aestetic_rewards.py`. The actual API is:

```python
def impact_velocity(
    env, sensor_cfg, force_threshold=10.0,
    kernel: str = "l1",   # "l1" or "l2"
) -> torch.Tensor:
```

The `_l1` suffix was mistakenly used as a function name instead of being passed as the `kernel` argument.

## Impact

Causes an `AttributeError` at environment construction time for:
- `Velocity-Height-G1-v0`
- `Velocity-Height-G1-Distillation-Recurrent-v0`
- `Velocity-Height-G1-Distillation-History-v0`
- Any task inheriting from `G1LowerVelocityHeightEnvCfg`

## Changes

- `agile/rl_env/tasks/locomotion_height/g1/velocity_height_env_cfg.py`: replace `mdp.impact_velocity_l1` → `mdp.impact_velocity` and add `"kernel": "l1"` to params

## Test plan
- [x] `python scripts/train.py --task Velocity-Height-G1-v0 --num_envs 16 --headless --max_iterations 5` runs without error
- [x] `python scripts/train.py --task Velocity-Height-G1-Distillation-Recurrent-v0 --num_envs 16 --headless --max_iterations 5` runs without error
- [x] `python scripts/train.py --task Velocity-Height-G1-Distillation-History-v0 --num_envs 16 --headless --max_iterations 5` runs without error

Signed-off-by: yingru <yingru@baidu.com>