### PR TITLE
feat: add velocity-height recurrent student policy ONNX for G1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,4 @@ docs/videos/unitree_g1_dancing_sim.gif filter=lfs diff=lfs merge=lfs -text
 docs/videos/unitree_g1_updown.gif filter=lfs diff=lfs merge=lfs -text
 docs/videos/unitree_g1_updown_sim.gif filter=lfs diff=lfs merge=lfs -text
 docs/videos/g1_apple_grasp_black_sort_bin_multi_objects_no_marker_reduced.gif filter=lfs diff=lfs merge=lfs -text
+agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx filter=lfs diff=lfs merge=lfs -text

--- a/agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx
+++ b/agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8e30ec353bbba464298aeb051963cee17e1f1a484081c726ebb1d7513570da6
+size 2050687


### PR DESCRIPTION
## Summary   

  Add the velocity-height recurrent student policy ONNX for the Unitree G1.                                                                                                              
   
  ## Motivation                                                                                                                                                                          
                                                         
  The velocity-height recurrent student policy is needed for sim2real and sim2mujoco workflows on G1, enabling deployment of the trained student policy alongside existing G1 policy     
  assets.
                                                                                                                                                                                         
  ## Changes                                             

  - Add `agile/data/policy/velocity_height_g1/unitree_g1_velocity_height_recurrent_student.onnx` (tracked via Git LFS)                                                                   
  - Update `.gitattributes` to register the new ONNX file with the LFS filter
                                                                                                                                                                                         
  ## Testing                                             
                                                                                                                                                                                         
  - Verified locally by loading and running the ONNX file 