### PR TITLE
Release v1.3.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+          path: current
+      - name: Check out the v1.2 documentation
+        uses: actions/checkout@v4
+        with:
+          ref: v1.2
+          lfs: true
+          path: v1.2
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -28,11 +35,13 @@ jobs:
         run: |
           pip install uv
           uv pip install --system 'sphinx>=8.0' nvidia-sphinx-theme myst-parser sphinx-design
-      - name: Build Sphinx docs
-        run: sphinx-build docs/source docs/build/html
+      - name: Build current and archived Sphinx docs
+        run: |
+          sphinx-build current/docs/source site
+          sphinx-build v1.2/docs/source site/v1.2
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/build/html
+          path: site
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,6 +4,12 @@
 
 AGILE is an [external Isaac Lab project](https://isaac-sim.github.io/IsaacLab/main/source/overview/own-project/template.html) that showcases how to build a full RL training pipeline on top of Isaac Lab, from task design and training to evaluation and sim-to-real deployment.
 
+```{note}
+These docs describe the current v1.3 release line. The archived
+[v1.2 documentation](https://nvidia-isaac.github.io/WBC-AGILE/v1.2/)
+remains available for users of the previous release.
+```
+
 <table align="center">
   <tr>
     <th colspan="2">Booster T1 - Stand-Up</th>
@@ -111,6 +117,7 @@ sim2mujoco
 
 remote-training
 testing
+AGILE v1.3.1 <releases/v1.3.1>
 AGILE v1.3.0 <releases/v1.3.0>
 Release note template <releases/_template>
 ```

--- a/docs/source/releases/v1.3.1.md
+++ b/docs/source/releases/v1.3.1.md
@@ -1,0 +1,21 @@
+# AGILE v1.3.1
+
+## Summary
+
+AGILE v1.3.1 restores access to the v1.2 documentation while retaining the
+v1.3 documentation at its existing GitHub Pages URL.
+
+## User-visible changes
+
+- Added an archived copy of the v1.2 documentation at
+  `https://nvidia-isaac.github.io/WBC-AGILE/v1.2/`.
+- Added a link from the current documentation to the v1.2 archive.
+
+## Upgrade notes
+
+- No code or configuration changes are required.
+
+## Known limitations
+
+- The archived documentation describes the v1.2 release and is not updated
+  with changes from the v1.3 release line.


### PR DESCRIPTION
## Summary

- keep the current v1.3 documentation at the existing GitHub Pages root
- restore the v1.2 documentation under `/v1.2/`
- publish the v1.3.1 release notes

## Validation

- internal release pipeline 65358022: all required jobs passed
- Copybara authenticated dry run passed
- staging attestation: `9c4f0de860e0727e6d4a06de1e5156afee78f9e7`
- public candidate: `d522d5f77ac98b186633440f096e1f9095606cd5`
- public diff is limited to the Pages workflow, docs index, and v1.3.1 release notes

Release: https://github.com/nvidia-isaac/WBC-AGILE/releases/tag/v1.3.1